### PR TITLE
Initial 1.12 port

### DIFF
--- a/src/main/java/zmaster587/advancedRocketry/AdvancedRocketry.java
+++ b/src/main/java/zmaster587/advancedRocketry/AdvancedRocketry.java
@@ -28,6 +28,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
 import net.minecraft.entity.item.EntityArmorStand;
 import net.minecraft.init.Biomes;
+import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
@@ -62,6 +63,8 @@ import net.minecraftforge.fml.common.network.NetworkRegistry;
 import net.minecraftforge.fml.common.registry.EntityRegistry;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.oredict.OreDictionary;
+import net.minecraftforge.oredict.ShapedOreRecipe;
+import net.minecraftforge.oredict.ShapelessOreRecipe;
 import net.minecraftforge.oredict.OreDictionary.OreRegisterEvent;
 import net.minecraftforge.registries.GameData;
 import zmaster587.advancedRocketry.api.AdvancedRocketryAPI;
@@ -1023,145 +1026,274 @@ public class AdvancedRocketry {
     public void registerRecipes(FMLInitializationEvent evt)
     {
         List<net.minecraft.item.crafting.IRecipe> toRegister = Lists.newArrayList();
+        ItemStack userInterface = new ItemStack(AdvancedRocketryItems.itemMisc, 1,0);
+        ItemStack basicCircuit = new ItemStack(AdvancedRocketryItems.itemIC, 1,0);
+        ItemStack advancedCircuit = new ItemStack(AdvancedRocketryItems.itemIC, 1,2);
+        ItemStack controlCircuitBoard =  new ItemStack(AdvancedRocketryItems.itemIC,1,3);
+        ItemStack itemIOBoard = new ItemStack(AdvancedRocketryItems.itemIC,1,4);
+        ItemStack liquidIOBoard = new ItemStack(AdvancedRocketryItems.itemIC,1,5);
+        ItemStack trackingCircuit = new ItemStack(AdvancedRocketryItems.itemIC,1,1);
+        ItemStack opticalSensor = new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 0);
+        ItemStack massDetector = new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 2);
+        ItemStack biomeChanger = new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 5);
+        ItemStack smallSolarPanel =  new ItemStack(AdvancedRocketryItems.itemSatellitePowerSource,1,0); 
+        ItemStack largeSolarPanel = new ItemStack(AdvancedRocketryItems.itemSatellitePowerSource,1,1);
+        ItemStack smallBattery = new ItemStack(LibVulpesItems.itemBattery,1,0);
+        ItemStack battery2x = new ItemStack(LibVulpesItems.itemBattery,1,1);
+        ItemStack superHighPressureTime = new ItemStack(AdvancedRocketryItems.itemPressureTank,1,3);
+        ItemStack charcoal = new ItemStack(Items.COAL,1,1);
         //TODO recipes.
-//      GameRegistry.addShapelessRecipe(new ItemStack(AdvancedRocketryBlocks.blockBlastBrick,16), new ItemStack(Items.MAGMA_CREAM,1), new ItemStack(Items.MAGMA_CREAM,1), Blocks.BRICK_BLOCK, Blocks.BRICK_BLOCK, Blocks.BRICK_BLOCK, Blocks.BRICK_BLOCK);
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockArcFurnace), "aga","ice", "aba", 'a', Items.NETHERBRICK, 'g', userInterface, 'i', itemIOBoard, 'e',controlCircuitBoard, 'c', AdvancedRocketryBlocks.blockBlastBrick, 'b', "ingotCopper"));
-//      GameRegistry.addShapedRecipe(new ItemStack(AdvancedRocketryItems.itemQuartzCrucible), " a ", "aba", " a ", Character.valueOf('a'), Items.QUARTZ, Character.valueOf('b'), Items.CAULDRON);
-//      GameRegistry.addRecipe(new ShapedOreRecipe(MaterialRegistry.getItemStackFromMaterialAndType("Iron", AllowedProducts.getProductByName("STICK"), 4), "x  ", " x ", "  x", 'x', "ingotIron"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(AdvancedRocketryBlocks.blockPlatePress, "   ", " a ", "iii", 'a', Blocks.PISTON, 'i', "ingotIron"));
-//      GameRegistry.addSmelting(MaterialRegistry.getMaterialFromName("Dilithium").getProduct(AllowedProducts.getProductByName("ORE")), MaterialRegistry.getMaterialFromName("Dilithium").getProduct(AllowedProducts.getProductByName("DUST")), 0);
+
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(LibVulpesItems.itemLinker), "x","y","z", 'x', Items.REDSTONE, 'y', Items.GOLD_INGOT, 'z', Items.IRON_INGOT).
+                setRegistryName(new ResourceLocation("libvulpes", "itemlinker")));
+
+        toRegister.add(new ShapelessOreRecipe(null, new ItemStack(LibVulpesBlocks.blockHatch,1,0), new ItemStack(LibVulpesBlocks.blockHatch,1,1)).
+              setRegistryName(new ResourceLocation("libvulpes", "blockhatchdir01")));
+
+
+
+        toRegister.add(new ShapelessOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockBlastBrick,16), new ItemStack(Items.MAGMA_CREAM,1), new ItemStack(Items.MAGMA_CREAM,1), Blocks.BRICK_BLOCK, Blocks.BRICK_BLOCK, Blocks.BRICK_BLOCK, Blocks.BRICK_BLOCK).
+              setRegistryName(new ResourceLocation("advancedrocketry", "blockBlastBrick")));
+        toRegister.add(new ShapedOreRecipe(null,new ItemStack(AdvancedRocketryBlocks.blockArcFurnace), "aga","ice", "aba", 'a', Items.NETHERBRICK, 'g', userInterface, 'i', itemIOBoard, 'e',controlCircuitBoard, 'c', AdvancedRocketryBlocks.blockBlastBrick, 'b', "ingotCopper").
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockArcFurnace")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryItems.itemQuartzCrucible), " a ", "aba", " a ", Character.valueOf('a'), Items.QUARTZ, Character.valueOf('b'), Items.CAULDRON).
+                setRegistryName(new ResourceLocation("advancedrocketry", "itemQuartzCrucible")));
+        toRegister.add(new ShapedOreRecipe(null, MaterialRegistry.getItemStackFromMaterialAndType("Iron", AllowedProducts.getProductByName("STICK"), 4), "x  ", " x ", "  x", 'x', "ingotIron").
+                setRegistryName(new ResourceLocation("advancedrocketry", "ironstick")));
+        toRegister.add(new ShapedOreRecipe(null, AdvancedRocketryBlocks.blockPlatePress, "   ", " a ", "iii", 'a', Blocks.PISTON, 'i', "ingotIron").
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockPlatePress")));
+        GameRegistry.addSmelting(MaterialRegistry.getMaterialFromName("Dilithium").getProduct(AllowedProducts.getProductByName("ORE")), MaterialRegistry.getMaterialFromName("Dilithium").getProduct(AllowedProducts.getProductByName("DUST")), 0);
 //
 //      //Supporting Materials
-//      GameRegistry.addRecipe(new ShapedOreRecipe(userInterface, "lrl", "fgf", 'l', "dyeLime", 'r', "dustRedstone", 'g', Blocks.GLASS_PANE, 'f', Items.GLOWSTONE_DUST));
-//      GameRegistry.addShapedRecipe(new ItemStack(AdvancedRocketryBlocks.blockGenericSeat), "xxx", 'x', Blocks.WOOL);
-//      GameRegistry.addShapelessRecipe(new ItemStack(AdvancedRocketryBlocks.blockConcrete, 16), Blocks.SAND, Blocks.GRAVEL, Items.WATER_BUCKET);
-//      GameRegistry.addRecipe(new ShapelessOreRecipe(AdvancedRocketryBlocks.blockLaunchpad, "concrete", "dyeBlack", "dyeYellow"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockStructureTower, 8), "ooo", " o ", "ooo", 'o', "stickSteel"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(AdvancedRocketryBlocks.blockEngine, "sss", " t ","t t", 's', "ingotSteel", 't', "plateTitanium"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(AdvancedRocketryBlocks.blockAdvEngine, "sss", " t ","t t", 's', "ingotTitaniumAluminide", 't', "plateTitaniumIridium"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(AdvancedRocketryBlocks.blockFuelTank, "s s", "p p", "s s", 'p', "plateSteel", 's', "stickSteel"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(LibVulpesItems.itemBattery,4,0), " c ","prp", "prp", 'c', "stickIron", 'r', "dustRedstone", 'p', "plateTin"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(LibVulpesItems.itemBattery,1,1), "bpb", "bpb", 'b', smallBattery, 'p', "plateCopper"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 0), "ppp", " g ", " l ", 'p', Blocks.GLASS_PANE, 'g', Items.GLOWSTONE_DUST, 'l', "plateGold"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockObservatory), "gug", "pbp", "rrr", 'g', "paneGlass", 'u', userInterface, 'b', LibVulpesBlocks.blockStructureBlock, 'r', "stickIron"));
+        toRegister.add(new ShapedOreRecipe(null, userInterface, "lrl", "fgf", 'l', "dyeLime", 'r', "dustRedstone", 'g', Blocks.GLASS_PANE, 'f', Items.GLOWSTONE_DUST).
+                setRegistryName(new ResourceLocation("advancedrocketry", "userInterface")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockGenericSeat), "xxx", 'x', Blocks.WOOL).
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockGenericSeat")));
+        toRegister.add(new ShapelessOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockConcrete, 16), Blocks.SAND, Blocks.GRAVEL, Items.WATER_BUCKET).
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockConcrete")));
+        toRegister.add(new ShapelessOreRecipe(null, AdvancedRocketryBlocks.blockLaunchpad, "concrete", "dyeBlack", "dyeYellow").
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockLaunchpad")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockStructureTower, 8), "ooo", " o ", "ooo", 'o', "stickSteel").
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockStructureTower")));
+        toRegister.add(new ShapedOreRecipe(null, AdvancedRocketryBlocks.blockEngine, "sss", " t ","t t", 's', "ingotSteel", 't', "plateTitanium").
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockEngine")));
+        toRegister.add(new ShapedOreRecipe(null, AdvancedRocketryBlocks.blockAdvEngine, "sss", " t ","t t", 's', "ingotTitaniumAluminide", 't', "plateTitaniumIridium").
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockAdvEngine")));
+        toRegister.add(new ShapedOreRecipe(null, AdvancedRocketryBlocks.blockFuelTank, "s s", "p p", "s s", 'p', "plateSteel", 's', "stickSteel").
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockFuelTank")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(LibVulpesItems.itemBattery,4,0), " c ","prp", "prp", 'c', "stickIron", 'r', "dustRedstone", 'p', "plateTin").
+                setRegistryName(new ResourceLocation("advancedrocketry", "itemBattery40")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(LibVulpesItems.itemBattery,1,1), "bpb", "bpb", 'b', smallBattery, 'p', "plateCopper").
+                setRegistryName(new ResourceLocation("advancedrocketry", "itemBattery11")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 0), "ppp", " g ", " l ", 'p', Blocks.GLASS_PANE, 'g', Items.GLOWSTONE_DUST, 'l', "plateGold").
+                setRegistryName(new ResourceLocation("advancedrocketry", "itemSatellitePrimaryFunction")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockObservatory), "gug", " b ", "rrr", 'g', "paneGlass", 'u', userInterface, 'b', LibVulpesBlocks.blockStructureBlock, 'r', "stickIron").
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockObservatory")));
+        
 //
 //      //Hatches
-//      GameRegistry.addShapedRecipe(new ItemStack(AdvancedRocketryBlocks.blockLoader,1,0), "m", "c"," ", 'c', AdvancedRocketryItems.itemDataUnit, 'm', LibVulpesBlocks.blockStructureBlock);
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockLoader,1,1), " x ", "xmx"," x ", 'x', "stickTitanium", 'm', LibVulpesBlocks.blockStructureBlock));
-//      GameRegistry.addShapelessRecipe(new ItemStack(AdvancedRocketryBlocks.blockLoader,1,2), new ItemStack(LibVulpesBlocks.blockHatch,1,1), trackingCircuit);
-//      GameRegistry.addShapelessRecipe(new ItemStack(AdvancedRocketryBlocks.blockLoader,1,3), new ItemStack(LibVulpesBlocks.blockHatch,1,0), trackingCircuit);
-//      GameRegistry.addShapelessRecipe(new ItemStack(AdvancedRocketryBlocks.blockLoader,1,4), new ItemStack(LibVulpesBlocks.blockHatch,1,3), trackingCircuit);
-//      GameRegistry.addShapelessRecipe(new ItemStack(AdvancedRocketryBlocks.blockLoader,1,5), new ItemStack(LibVulpesBlocks.blockHatch,1,2), trackingCircuit);
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockLoader,1,6), " z ", "xmx"," z ", 'z' , controlCircuitBoard, 'x', "stickCopper", 'm', LibVulpesBlocks.blockStructureBlock));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockLoader,1,0), "m", "c"," ", 'c', AdvancedRocketryItems.itemDataUnit, 'm', LibVulpesBlocks.blockStructureBlock).
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockLoader10")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockLoader,1,1), " x ", "xmx"," x ", 'x', "stickTitanium", 'm', LibVulpesBlocks.blockStructureBlock).
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockLoader11")));
+        toRegister.add(new ShapelessOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockLoader,1,2), new ItemStack(LibVulpesBlocks.blockHatch,1,1), trackingCircuit).
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockLoader12")));
+        toRegister.add(new ShapelessOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockLoader,1,3), new ItemStack(LibVulpesBlocks.blockHatch,1,0), trackingCircuit).
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockLoader13")));
+        toRegister.add(new ShapelessOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockLoader,1,4), new ItemStack(LibVulpesBlocks.blockHatch,1,3), trackingCircuit).
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockLoader14")));
+        toRegister.add(new ShapelessOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockLoader,1,5), new ItemStack(LibVulpesBlocks.blockHatch,1,2), trackingCircuit).
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockLoader15")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockLoader,1,6), " z ", "xmx"," z ", 'z' , controlCircuitBoard, 'x', "stickCopper", 'm', LibVulpesBlocks.blockStructureBlock).
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockLoader16")));
 //      
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryItems.itemSatellitePowerSource,1,0), "rrr", "ggg","ppp", 'r', "dustRedstone", 'g', Items.GLOWSTONE_DUST, 'p', "plateGold"));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryItems.itemSatellitePowerSource,1,0), "rrr", "ggg","ppp", 'r', "dustRedstone", 'g', Items.GLOWSTONE_DUST, 'p', "plateGold").
+                setRegistryName(new ResourceLocation("advancedrocketry", "itemSatellitePowerSource")));
 //
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(LibVulpesItems.itemHoloProjector), "oro", "rpr", 'o', new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 0), 'r', "dustRedstone", 'p', "plateIron"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(massDetector, "odo", "pcp", 'o', new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 0), 'p', new ItemStack(AdvancedRocketryItems.itemWafer,1,0), 'c', basicCircuit, 'd', "crystalDilithium"));
-//      GameRegistry.addShapedRecipe(new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 1), "odo", "pcp", 'o', new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 0), 'p', new ItemStack(AdvancedRocketryItems.itemWafer,1,0), 'c', basicCircuit, 'd', trackingCircuit);
-//      GameRegistry.addShapedRecipe(new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 3), "odo", "pcp", 'o', new ItemStack(AdvancedRocketryItems.itemLens, 1, 0), 'p', new ItemStack(AdvancedRocketryItems.itemWafer,1,0), 'c', basicCircuit, 'd', trackingCircuit);
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(LibVulpesItems.itemHoloProjector), "oro", "rpr", 'o', new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 0), 'r', "dustRedstone", 'p', "plateIron").
+                setRegistryName(new ResourceLocation("advancedrocketry", "itemHoloProjector")));
+        toRegister.add(new ShapedOreRecipe(null, massDetector, "odo", "pcp", 'o', new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 0), 'p', new ItemStack(AdvancedRocketryItems.itemWafer,1,0), 'c', basicCircuit, 'd', "crystalDilithium").
+                setRegistryName(new ResourceLocation("advancedrocketry", "massDetector")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 1), "odo", "pcp", 'o', new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 0), 'p', new ItemStack(AdvancedRocketryItems.itemWafer,1,0), 'c', basicCircuit, 'd', trackingCircuit).
+                setRegistryName(new ResourceLocation("advancedrocketry", "itemSatellitePrimaryFunction11")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 3), "odo", "pcp", 'o', new ItemStack(AdvancedRocketryItems.itemLens, 1, 0), 'p', new ItemStack(AdvancedRocketryItems.itemWafer,1,0), 'c', basicCircuit, 'd', trackingCircuit).
+                setRegistryName(new ResourceLocation("advancedrocketry", "itemSatellitePrimaryFunction13")));
 //
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryItems.itemSawBlade,1,0), " x ","xox", " x ", 'x', "plateIron", 'o', "stickIron"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockSawBlade,1,0), "r r","xox", "x x", 'r', "stickIron", 'x', "plateIron", 'o', new ItemStack(AdvancedRocketryItems.itemSawBlade,1,0)));
-//      GameRegistry.addShapelessRecipe(new ItemStack(AdvancedRocketryItems.itemSpaceStationChip), LibVulpesItems.itemLinker , basicCircuit);
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryItems.itemCarbonScrubberCartridge), "xix", "xix", "xix", 'x', "sheetIron", 'i', Blocks.IRON_BARS));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryItems.itemSawBlade,1,0), " x ","xox", " x ", 'x', "plateIron", 'o', "stickIron").
+                setRegistryName(new ResourceLocation("advancedrocketry", "itemSawBlade")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockSawBlade,1,0), "r r","xox", "x x", 'r', "stickIron", 'x', "plateIron", 'o', new ItemStack(AdvancedRocketryItems.itemSawBlade,1,0)).
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockSawBlade")));
+        toRegister.add(new ShapelessOreRecipe(null, new ItemStack(AdvancedRocketryItems.itemSpaceStationChip), LibVulpesItems.itemLinker , basicCircuit).
+                setRegistryName(new ResourceLocation("advancedrocketry", "itemSpaceStationChip")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryItems.itemCarbonScrubberCartridge), "xix", "xix", "xix", 'x', "sheetIron", 'i', Blocks.IRON_BARS).
+                setRegistryName(new ResourceLocation("advancedrocketry", "itemCarbonScrubberCartridge")));
 //
 //      //O2 Support
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockOxygenVent), "bfb", "bmb", "btb", 'b', Blocks.IRON_BARS, 'f', "fanSteel", 'm', LibVulpesBlocks.blockMotor, 't', AdvancedRocketryBlocks.blockFuelTank));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockOxygenScrubber), "bfb", "bmb", "btb", 'b', Blocks.IRON_BARS, 'f', "fanSteel", 'm', LibVulpesBlocks.blockMotor, 't', "ingotCarbon"));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockOxygenVent), "bfb", "bmb", "btb", 'b', Blocks.IRON_BARS, 'f', "fanSteel", 'm', LibVulpesBlocks.blockMotor, 't', AdvancedRocketryBlocks.blockFuelTank).
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockOxygenVent")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockOxygenScrubber), "bfb", "bmb", "btb", 'b', Blocks.IRON_BARS, 'f', "fanSteel", 'm', LibVulpesBlocks.blockMotor, 't', "ingotCarbon").
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockOxygenScrubber")));
 //
 //      //Knicknacks
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockForceFieldProjector), " c ", "pdp","psp", 'c', "coilCopper", 'p', "plateAluminum", 'd', "crystalDilithium", 's', LibVulpesBlocks.blockStructureBlock));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(AdvancedRocketryBlocks.blockPipeSealer, " c ", "csc", " c ", 'c', Items.CLAY_BALL, 's', "stickIron"));
-//      GameRegistry.addShapelessRecipe(new ItemStack(AdvancedRocketryBlocks.blockAlienPlanks, 4), AdvancedRocketryBlocks.blockAlienWood);
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockForceFieldProjector), " c ", "pdp","psp", 'c', "coilCopper", 'p', "plateAluminum", 'd', "crystalDilithium", 's', LibVulpesBlocks.blockStructureBlock).
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockForceFieldProjector")));
+        toRegister.add(new ShapedOreRecipe(null, AdvancedRocketryBlocks.blockPipeSealer, " c ", "csc", " c ", 'c', Items.CLAY_BALL, 's', "stickIron").
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockPipeSealer")));
+        toRegister.add(new ShapelessOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockAlienPlanks, 4), AdvancedRocketryBlocks.blockAlienWood).
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockAlienPlanks")));
 //      
 //      if(zmaster587.advancedRocketry.api.Configuration.enableGravityController)
-//          GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockGravityMachine), "sds", "sws", 's', "sheetTitanium", 'd', massDetector, 'w', AdvancedRocketryBlocks.blockWarpCore));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockGravityMachine), "sds", "sws", 's', "sheetTitanium", 'd', massDetector, 'w', AdvancedRocketryBlocks.blockWarpCore).
+                setRegistryName(new ResourceLocation("advancedrocketry", "blockGravityMachine")));
 //
 //      //MACHINES
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockPrecisionAssembler), "abc", "def", "ghi", 'a', Items.REPEATER, 'b', userInterface, 'c', "gemDiamond", 'd', itemIOBoard, 'e', LibVulpesBlocks.blockStructureBlock, 'f', controlCircuitBoard, 'g', Blocks.FURNACE, 'h', "gearSteel", 'i', Blocks.DROPPER));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockCrystallizer), "ada", "ecf","bgb", 'a', Items.QUARTZ, 'b', Items.REPEATER, 'c', LibVulpesBlocks.blockStructureBlock, 'd', userInterface, 'e', itemIOBoard, 'f', controlCircuitBoard, 'g', "plateSteel"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockCuttingMachine), "aba", "cde", "opo", 'a', "gearSteel", 'b', userInterface, 'c', itemIOBoard, 'e', controlCircuitBoard, 'p', "plateSteel", 'o', Blocks.OBSIDIAN, 'd', LibVulpesBlocks.blockStructureBlock));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockLathe), "rsr", "abc", "pgp", 'r', "stickIron",'a', itemIOBoard, 'c', controlCircuitBoard, 'g', "gearSteel", 'p', "plateSteel", 'b', LibVulpesBlocks.blockStructureBlock, 's', userInterface));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockRollingMachine), "psp", "abc", "iti", 'a', itemIOBoard, 'c', controlCircuitBoard, 'p', "gearSteel", 's', userInterface, 'b', LibVulpesBlocks.blockStructureBlock, 'i', "blockIron",'t', liquidIOBoard));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockMonitoringStation), "coc", "cbc", "cpc", 'c', "stickCopper", 'o', new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 0), 'b', LibVulpesBlocks.blockStructureBlock, 'p', LibVulpesItems.itemBattery));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockFuelingStation), "bgb", "lbf", "ppp", 'p', "plateTin", 'f', "fanSteel", 'l', liquidIOBoard, 'g', AdvancedRocketryItems.itemMisc, 'x', AdvancedRocketryBlocks.blockFuelTank, 'b', LibVulpesBlocks.blockStructureBlock));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockSatelliteControlCenter), "oso", "cbc", "rtr", 'o', new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 0), 's', userInterface, 'c', "stickCopper", 'b', LibVulpesBlocks.blockStructureBlock, 'r', Items.REPEATER, 't', LibVulpesItems.itemBattery));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockSatelliteBuilder), "dht", "cbc", "mas", 'd', AdvancedRocketryItems.itemDataUnit, 'h', Blocks.HOPPER, 'c', basicCircuit, 'b', LibVulpesBlocks.blockStructureBlock, 'm', LibVulpesBlocks.blockMotor, 'a', Blocks.ANVIL, 's', AdvancedRocketryBlocks.blockSawBlade, 't', "plateTitanium"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockPlanetAnalyser), "tst", "pbp", "cpc", 't', trackingCircuit, 's', userInterface, 'b', LibVulpesBlocks.blockStructureBlock, 'p', "plateTin", 'c', AdvancedRocketryItems.itemPlanetIdChip));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockGuidanceComputer), "ctc", "rbr", "crc", 'c', trackingCircuit, 't', "plateTitanium", 'r', "dustRedstone", 'b', LibVulpesBlocks.blockStructureBlock));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockPlanetSelector), "cpc", "lbl", "coc", 'c', trackingCircuit, 'o',new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 0), 'l', Blocks.LEVER, 'b', AdvancedRocketryBlocks.blockGuidanceComputer, 'p', Blocks.STONE_BUTTON));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockRocketBuilder), "sgs", "cbc", "tdt", 's', "stickTitanium", 'g', AdvancedRocketryItems.itemMisc, 'c', controlCircuitBoard, 'b', LibVulpesBlocks.blockStructureBlock, 't', "gearTitanium", 'd', AdvancedRocketryBlocks.blockConcrete));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockStationBuilder), "gdg", "dsd", "ada", 'g', "gearTitanium", 'a', advancedCircuit, 'd', "dustDilithium", 's', new ItemStack(AdvancedRocketryBlocks.blockRocketBuilder)));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockElectrolyser), "pip", "abc", "ded", 'd', basicCircuit, 'p', "plateSteel", 'i', userInterface, 'a', liquidIOBoard, 'c', controlCircuitBoard, 'b', LibVulpesBlocks.blockStructureBlock, 'e', Blocks.REDSTONE_TORCH));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockOxygenCharger), "fif", "tbt", "pcp", 'p', "plateSteel", 'f', "fanSteel", 'c', Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE, 'i', AdvancedRocketryItems.itemMisc, 'b', LibVulpesBlocks.blockStructureBlock, 't', AdvancedRocketryBlocks.blockFuelTank));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockChemicalReactor), "pip", "abd", "rcr", 'a', itemIOBoard, 'd', controlCircuitBoard, 'r', basicCircuit, 'p', "plateGold", 'i', userInterface, 'c', liquidIOBoard, 'b', LibVulpesBlocks.blockStructureBlock, 'g', "plateGold"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockWarpCore), "gcg", "pbp", "gcg", 'p', "plateSteel", 'c', advancedCircuit, 'b', "coilCopper", 'g', "plateTitanium"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockOxygenDetection), "pip", "gbf", "pcp", 'p', "plateSteel",'f', "fanSteel", 'i', userInterface, 'c', basicCircuit, 'b', LibVulpesBlocks.blockStructureBlock, 'g', Blocks.IRON_BARS));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockWarpShipMonitor), "pip", "obo", "pcp", 'o', controlCircuitBoard, 'p', "plateSteel", 'i', userInterface, 'c', advancedCircuit, 'b', LibVulpesBlocks.blockStructureBlock));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockBiomeScanner), "plp", "bsb","ppp", 'p', "plateTin", 'l', biomeChanger, 'b', smallBattery, 's', LibVulpesBlocks.blockStructureBlock));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockDeployableRocketBuilder), "gdg", "dad", "rdr", 'g', "gearTitaniumAluminide", 'd', "dustDilithium", 'r', "stickTitaniumAluminide", 'a', AdvancedRocketryBlocks.blockRocketBuilder));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockPressureTank), "tgt","tgt","tgt", 't', superHighPressureTime, 'g', Blocks.GLASS_PANE));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockIntake), "rhr", "hbh", "rhr", 'r', "stickTitanium", 'h', Blocks.HOPPER, 'b', LibVulpesBlocks.blockStructureBlock));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockRailgun), " t ", "abc", "ded", 't', trackingCircuit, 'a', controlCircuitBoard, 'b', LibVulpesBlocks.blockAdvStructureBlock, 'c', itemIOBoard, 'd', "fanSteel", 'e', "coilCopper"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockSpaceElevatorController), " d ", "aba", "ccc", 'd', controlCircuitBoard, 'a', advancedCircuit, 'b', LibVulpesBlocks.blockAdvStructureBlock, 'c', "coilAluminum"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockBeacon), " c ", "dbt", "scs", 'c', "coilCopper", 'd', controlCircuitBoard, 't', trackingCircuit, 'b', LibVulpesBlocks.blockStructureBlock, 's', "sheetIron" ));
-//
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockPrecisionAssembler), "abc", "def", "ghi", 'a', Items.REPEATER, 'b', userInterface, 'c', "gemDiamond", 'd', itemIOBoard, 'e', LibVulpesBlocks.blockStructureBlock, 'f', controlCircuitBoard, 'g', Blocks.FURNACE, 'h', "gearSteel", 'i', Blocks.DROPPER).
+        setRegistryName(new ResourceLocation("advancedrocketry", "blockPrecisionAssembler")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockCrystallizer), "ada", "ecf","bgb", 'a', Items.QUARTZ, 'b', Items.REPEATER, 'c', LibVulpesBlocks.blockStructureBlock, 'd', userInterface, 'e', itemIOBoard, 'f', controlCircuitBoard, 'g', "plateSteel").
+        setRegistryName(new ResourceLocation("advancedrocketry", "blockCrystallizer")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockCuttingMachine), "aba", "cde", "opo", 'a', "gearSteel", 'b', userInterface, 'c', itemIOBoard, 'e', controlCircuitBoard, 'p', "plateSteel", 'o', Blocks.OBSIDIAN, 'd', LibVulpesBlocks.blockStructureBlock).
+        setRegistryName(new ResourceLocation("advancedrocketry", "blockCuttingMachine")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockLathe), "rsr", "abc", "pgp", 'r', "stickIron",'a', itemIOBoard, 'c', controlCircuitBoard, 'g', "gearSteel", 'p', "plateSteel", 'b', LibVulpesBlocks.blockStructureBlock, 's', userInterface).
+        setRegistryName(new ResourceLocation("advancedrocketry", "blockLathe")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockRollingMachine), "psp", "abc", "iti", 'a', itemIOBoard, 'c', controlCircuitBoard, 'p', "gearSteel", 's', userInterface, 'b', LibVulpesBlocks.blockStructureBlock, 'i', "blockIron",'t', liquidIOBoard).
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockRollingMachine")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockMonitoringStation), "coc", "cbc", "cpc", 'c', "stickCopper", 'o', new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 0), 'b', LibVulpesBlocks.blockStructureBlock, 'p', LibVulpesItems.itemBattery).
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockMonitoringStation")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockFuelingStation), "bgb", "lbf", "ppp", 'p', "plateTin", 'f', "fanSteel", 'l', liquidIOBoard, 'g', AdvancedRocketryItems.itemMisc, 'b', LibVulpesBlocks.blockStructureBlock).
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockFuelingStation")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockSatelliteControlCenter), "oso", "cbc", "rtr", 'o', new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 0), 's', userInterface, 'c', "stickCopper", 'b', LibVulpesBlocks.blockStructureBlock, 'r', Items.REPEATER, 't', LibVulpesItems.itemBattery).
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockSatelliteControlCenter")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockSatelliteBuilder), "dht", "cbc", "mas", 'd', AdvancedRocketryItems.itemDataUnit, 'h', Blocks.HOPPER, 'c', basicCircuit, 'b', LibVulpesBlocks.blockStructureBlock, 'm', LibVulpesBlocks.blockMotor, 'a', Blocks.ANVIL, 's', AdvancedRocketryBlocks.blockSawBlade, 't', "plateTitanium").
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockSatelliteBuilder")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockPlanetAnalyser), "tst", "pbp", "cpc", 't', trackingCircuit, 's', userInterface, 'b', LibVulpesBlocks.blockStructureBlock, 'p', "plateTin", 'c', AdvancedRocketryItems.itemPlanetIdChip).
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockPlanetAnalyser")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockGuidanceComputer), "ctc", "rbr", "crc", 'c', trackingCircuit, 't', "plateTitanium", 'r', "dustRedstone", 'b', LibVulpesBlocks.blockStructureBlock).
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockGuidanceComputer")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockPlanetSelector), "cpc", "lbl", "coc", 'c', trackingCircuit, 'o',new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 0), 'l', Blocks.LEVER, 'b', AdvancedRocketryBlocks.blockGuidanceComputer, 'p', Blocks.STONE_BUTTON).
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockPlanetSelector")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockRocketBuilder), "sgs", "cbc", "tdt", 's', "stickTitanium", 'g', AdvancedRocketryItems.itemMisc, 'c', controlCircuitBoard, 'b', LibVulpesBlocks.blockStructureBlock, 't', "gearTitanium", 'd', AdvancedRocketryBlocks.blockConcrete).
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockRocketBuilder")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockStationBuilder), "gdg", "dsd", "ada", 'g', "gearTitanium", 'a', advancedCircuit, 'd', "dustDilithium", 's', new ItemStack(AdvancedRocketryBlocks.blockRocketBuilder)).
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockStationBuilder")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockElectrolyser), "pip", "abc", "ded", 'd', basicCircuit, 'p', "plateSteel", 'i', userInterface, 'a', liquidIOBoard, 'c', controlCircuitBoard, 'b', LibVulpesBlocks.blockStructureBlock, 'e', Blocks.REDSTONE_TORCH).
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockElectrolyser")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockOxygenCharger), "fif", "tbt", "pcp", 'p', "plateSteel", 'f', "fanSteel", 'c', Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE, 'i', AdvancedRocketryItems.itemMisc, 'b', LibVulpesBlocks.blockStructureBlock, 't', AdvancedRocketryBlocks.blockFuelTank).
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockOxygenCharger")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockChemicalReactor), "pip", "abd", "rcr", 'a', itemIOBoard, 'd', controlCircuitBoard, 'r', basicCircuit, 'p', "plateGold", 'i', userInterface, 'c', liquidIOBoard, 'b', LibVulpesBlocks.blockStructureBlock).
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockChemicalReactor")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockWarpCore), "gcg", "pbp", "gcg", 'p', "plateSteel", 'c', advancedCircuit, 'b', "coilCopper", 'g', "plateTitanium").
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockWarpCore")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockOxygenDetection), "pip", "gbf", "pcp", 'p', "plateSteel",'f', "fanSteel", 'i', userInterface, 'c', basicCircuit, 'b', LibVulpesBlocks.blockStructureBlock, 'g', Blocks.IRON_BARS).
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockOxygenDetection")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockWarpShipMonitor), "pip", "obo", "pcp", 'o', controlCircuitBoard, 'p', "plateSteel", 'i', userInterface, 'c', advancedCircuit, 'b', LibVulpesBlocks.blockStructureBlock).
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockWarpShipMonitor")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockBiomeScanner), "plp", "bsb","ppp", 'p', "plateTin", 'l', biomeChanger, 'b', smallBattery, 's', LibVulpesBlocks.blockStructureBlock).
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockBiomeScanner")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockDeployableRocketBuilder), "gdg", "dad", "rdr", 'g', "gearTitaniumAluminide", 'd', "dustDilithium", 'r', "stickTitaniumAluminide", 'a', AdvancedRocketryBlocks.blockRocketBuilder).
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockDeployableRocketBuilder")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockPressureTank), "tgt","tgt","tgt", 't', superHighPressureTime, 'g', Blocks.GLASS_PANE).
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockPressureTank")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockIntake), "rhr", "hbh", "rhr", 'r', "stickTitanium", 'h', Blocks.HOPPER, 'b', LibVulpesBlocks.blockStructureBlock).
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockIntake")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockRailgun), " t ", "abc", "ded", 't', trackingCircuit, 'a', controlCircuitBoard, 'b', LibVulpesBlocks.blockAdvStructureBlock, 'c', itemIOBoard, 'd', "fanSteel", 'e', "coilCopper").
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockRailgun")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockSpaceElevatorController), " d ", "aba", "ccc", 'd', controlCircuitBoard, 'a', advancedCircuit, 'b', LibVulpesBlocks.blockAdvStructureBlock, 'c', "coilAluminum").
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockSpaceElevatorController")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockBeacon), " c ", "dbt", "scs", 'c', "coilCopper", 'd', controlCircuitBoard, 't', trackingCircuit, 'b', LibVulpesBlocks.blockStructureBlock, 's', "sheetIron" ).
+          setRegistryName(new ResourceLocation("advancedrocketry", "blockBeacon")));
 //      //Armor recipes
-//      GameRegistry.addRecipe(new ShapedOreRecipe(AdvancedRocketryItems.itemSpaceSuit_Boots, " r ", "w w", "p p", 'r', "stickIron", 'w', Blocks.WOOL, 'p', "plateIron"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(AdvancedRocketryItems.itemSpaceSuit_Leggings, "wrw", "w w", "w w", 'w', Blocks.WOOL, 'r', "stickIron"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(AdvancedRocketryItems.itemSpaceSuit_Chest, "wrw", "wtw", "wfw", 'w', Blocks.WOOL, 'r', "stickIron", 't', AdvancedRocketryBlocks.blockFuelTank, 'f', "fanSteel"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(AdvancedRocketryItems.itemSpaceSuit_Helmet, "prp", "rgr", "www", 'w', Blocks.WOOL, 'r', "stickIron", 'p', "plateIron", 'g', Blocks.GLASS_PANE));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(AdvancedRocketryItems.itemJetpack, "cpc", "lsl", "f f", 'c', AdvancedRocketryItems.itemPressureTank, 'f', Items.FIRE_CHARGE, 's', Items.STRING, 'l', Blocks.LEVER, 'p', "plateSteel"));
-//
-//      //Tool Recipes
-//      GameRegistry.addRecipe(new ShapedOreRecipe(AdvancedRocketryItems.itemJackhammer, " pt","imp","di ",'d', "gemDiamond", 'm', LibVulpesBlocks.blockMotor, 'p', "plateAluminum", 't', "stickTitanium", 'i', "stickIron"));
-//
-//      //Other blocks
-//      GameRegistry.addRecipe(new ShapedOreRecipe(AdvancedRocketryItems.itemSmallAirlockDoor, "pp", "pp","pp", 'p', "plateSteel"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockCircleLight), "p  ", " l ", "   ", 'p', "sheetIron", 'l', Blocks.GLOWSTONE));
-//
-//      //TEMP RECIPES
-//      GameRegistry.addShapelessRecipe(new ItemStack(AdvancedRocketryItems.itemSatelliteIdChip), new ItemStack(AdvancedRocketryItems.itemIC, 1, 0));
-//      GameRegistry.addShapelessRecipe(new ItemStack(AdvancedRocketryItems.itemPlanetIdChip), new ItemStack(AdvancedRocketryItems.itemIC, 1, 0), new ItemStack(AdvancedRocketryItems.itemIC, 1, 0), new ItemStack(AdvancedRocketryItems.itemSatelliteIdChip));
-//      GameRegistry.addShapelessRecipe(new ItemStack(AdvancedRocketryItems.itemMisc,1,1), charcoal, charcoal, charcoal, charcoal ,charcoal ,charcoal);
-//      GameRegistry.addShapelessRecipe(new ItemStack(AdvancedRocketryBlocks.blockLandingPad), new ItemStack(AdvancedRocketryBlocks.blockConcrete), trackingCircuit);
-//      GameRegistry.addShapelessRecipe(new ItemStack(AdvancedRocketryItems.itemAsteroidChip), trackingCircuit.copy(), AdvancedRocketryItems.itemDataUnit);
-//      GameRegistry.addShapedRecipe(new ItemStack(AdvancedRocketryBlocks.blockDataPipe, 8), "ggg", " d ", "ggg", 'g', Blocks.GLASS_PANE, 'd', AdvancedRocketryItems.itemDataUnit);
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockEnergyPipe, 32), "ggg", " d ", "ggg", 'g', Items.CLAY_BALL, 'd', "stickCopper"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockFluidPipe, 32), "ggg", " d ", "ggg", 'g', Items.CLAY_BALL, 'd', "sheetCopper"));
-//
-//      GameRegistry.addShapelessRecipe(new ItemStack(AdvancedRocketryBlocks.blockDrill), LibVulpesBlocks.blockStructureBlock, Items.IRON_PICKAXE);
-//      GameRegistry.addShapelessRecipe(new ItemStack(AdvancedRocketryBlocks.blockOrientationController), LibVulpesBlocks.blockStructureBlock, Items.COMPASS, userInterface);
-//      GameRegistry.addShapelessRecipe(new ItemStack(AdvancedRocketryBlocks.blockGravityController), LibVulpesBlocks.blockStructureBlock, Blocks.PISTON, Blocks.REDSTONE_BLOCK);
-//      GameRegistry.addShapelessRecipe(new ItemStack(AdvancedRocketryBlocks.blockAltitudeController), LibVulpesBlocks.blockStructureBlock, userInterface, basicCircuit);
-//
-//      GameRegistry.addShapedRecipe(new ItemStack(AdvancedRocketryItems.itemLens), " g ", "g g", 'g', Blocks.GLASS_PANE);
-//      GameRegistry.addShapelessRecipe(largeSolarPanel.copy(), smallSolarPanel, smallSolarPanel, smallSolarPanel, smallSolarPanel, smallSolarPanel, smallSolarPanel);
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockMicrowaveReciever), "ggg", "tbc", "aoa", 'g', "plateGold", 't', trackingCircuit, 'b', LibVulpesBlocks.blockStructureBlock, 'c', controlCircuitBoard, 'a', advancedCircuit, 'o', opticalSensor));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(AdvancedRocketryBlocks.blockSolarPanel, "rrr", "gbg", "ppp", 'r' , "dustRedstone", 'g', Items.GLOWSTONE_DUST, 'b', LibVulpesBlocks.blockStructureBlock, 'p', "plateGold"));
-//      GameRegistry.addRecipe(new ShapelessOreRecipe(AdvancedRocketryBlocks.blockSolarGenerator, "itemBattery", LibVulpesBlocks.blockForgeOutputPlug, AdvancedRocketryBlocks.blockSolarPanel));
-//      GameRegistry.addShapelessRecipe(new ItemStack(AdvancedRocketryBlocks.blockDockingPort), trackingCircuit, new ItemStack(AdvancedRocketryBlocks.blockLoader, 1,1));
-//
-//      GameRegistry.addRecipe(new ShapedOreRecipe(AdvancedRocketryItems.itemOreScanner, "lwl", "bgb", "   ", 'l', Blocks.LEVER, 'g', userInterface, 'b', "itemBattery", 'w', advancedCircuit));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 4), " c ","sss", "tot", 'c', "stickCopper", 's', "sheetIron", 'o', AdvancedRocketryItems.itemOreScanner, 't', trackingCircuit));
-//      GameRegistry.addShapedRecipe(new ItemStack(AdvancedRocketryBlocks.blockSuitWorkStation), "c","b", 'c', Blocks.CRAFTING_TABLE, 'b', LibVulpesBlocks.blockStructureBlock);
-//      GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryItems.itemSatellite), "sss", "rcr", "sss", 's', "sheetAluminum", 'r', "stickTitanium", 'c', controlCircuitBoard));
-//      
-//      
-//      if(zmaster587.advancedRocketry.api.Configuration.enableLaserDrill) {
-//          GameRegistry.addRecipe(new ShapedOreRecipe(AdvancedRocketryBlocks.blockSpaceLaser, "ata", "bec", "gpg", 'a', advancedCircuit, 't', trackingCircuit, 'b', LibVulpesItems.itemBattery, 'e', Items.EMERALD, 'c', controlCircuitBoard, 'g', "gearTitanium", 'p', LibVulpesBlocks.blockStructureBlock));
-//      }
-//      if(zmaster587.advancedRocketry.api.Configuration.allowTerraforming) {
-//          GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(AdvancedRocketryBlocks.blockAtmosphereTerraformer), "gdg", "lac", "gbg", 'g', "gearTitaniumAluminide", 'd', "crystalDilithium", 'l', liquidIOBoard, 'a', LibVulpesBlocks.blockAdvStructureBlock, 'c', controlCircuitBoard, 'b', battery2x));
-//      }
-//
-//      //Control boards
-//      GameRegistry.addRecipe(new ShapedOreRecipe(itemIOBoard, "rvr", "dwd", "dpd", 'r', "dustRedstone", 'v', "gemDiamond", 'd', "dustGold", 'w', "slabWood", 'p', "plateIron"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(controlCircuitBoard, "rvr", "dwd", "dpd", 'r', "dustRedstone", 'v', "gemDiamond", 'd', "dustCopper", 'w', "slabWood", 'p', "plateIron"));
-//      GameRegistry.addRecipe(new ShapedOreRecipe(liquidIOBoard, "rvr", "dwd", "dpd", 'r', "dustRedstone", 'v', "gemDiamond", 'd', new ItemStack(Items.DYE, 1, 4), 'w', "slabWood", 'p', "plateIron"));
-
+        toRegister.add(new ShapedOreRecipe(null, AdvancedRocketryItems.itemSpaceSuit_Boots, " r ", "w w", "p p", 'r', "stickIron", 'w', Blocks.WOOL, 'p', "plateIron").
+            setRegistryName(new ResourceLocation("advancedrocketry", "itemSpaceSuit_Boots")));
+        toRegister.add(new ShapedOreRecipe(null, AdvancedRocketryItems.itemSpaceSuit_Leggings, "wrw", "w w", "w w", 'w', Blocks.WOOL, 'r', "stickIron").
+            setRegistryName(new ResourceLocation("advancedrocketry", "itemSpaceSuit_Leggings")));
+        toRegister.add(new ShapedOreRecipe(null, AdvancedRocketryItems.itemSpaceSuit_Chest, "wrw", "wtw", "wfw", 'w', Blocks.WOOL, 'r', "stickIron", 't', AdvancedRocketryBlocks.blockFuelTank, 'f', "fanSteel").
+            setRegistryName(new ResourceLocation("advancedrocketry", "itemSpaceSuit_Chest")));
+        toRegister.add(new ShapedOreRecipe(null, AdvancedRocketryItems.itemSpaceSuit_Helmet, "prp", "rgr", "www", 'w', Blocks.WOOL, 'r', "stickIron", 'p', "plateIron", 'g', Blocks.GLASS_PANE).
+            setRegistryName(new ResourceLocation("advancedrocketry", "itemSpaceSuit_Helmet")));
+        toRegister.add(new ShapedOreRecipe(null, AdvancedRocketryItems.itemJetpack, "cpc", "lsl", "f f", 'c', AdvancedRocketryItems.itemPressureTank, 'f', Items.FIRE_CHARGE, 's', Items.STRING, 'l', Blocks.LEVER, 'p', "plateSteel").
+            setRegistryName(new ResourceLocation("advancedrocketry", "itemJetpack")));
+      //
+    //            //Tool Recipes
+        toRegister.add(new ShapedOreRecipe(null, AdvancedRocketryItems.itemJackhammer, " pt","imp","di ",'d', "gemDiamond", 'm', LibVulpesBlocks.blockMotor, 'p', "plateAluminum", 't', "stickTitanium", 'i', "stickIron").
+            setRegistryName(new ResourceLocation("advancedrocketry", "itemJackhammer")));
+      //
+    //            //Other blocks
+        toRegister.add(new ShapedOreRecipe(null, AdvancedRocketryItems.itemSmallAirlockDoor, "pp", "pp","pp", 'p', "plateSteel").
+            setRegistryName(new ResourceLocation("advancedrocketry", "itemSmallAirlockDoor")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockCircleLight), "p  ", " l ", "   ", 'p', "sheetIron", 'l', Blocks.GLOWSTONE).
+            setRegistryName(new ResourceLocation("advancedrocketry", "blockCircleLight")));
+      //
+    //            //TEMP RECIPES
+        toRegister.add(new ShapelessOreRecipe(null, new ItemStack(AdvancedRocketryItems.itemSatelliteIdChip), new ItemStack(AdvancedRocketryItems.itemIC, 1, 0)).
+            setRegistryName(new ResourceLocation("advancedrocketry", "itemSatelliteIdChip")));
+        toRegister.add(new ShapelessOreRecipe(null, new ItemStack(AdvancedRocketryItems.itemPlanetIdChip), new ItemStack(AdvancedRocketryItems.itemIC, 1, 0), new ItemStack(AdvancedRocketryItems.itemIC, 1, 0), new ItemStack(AdvancedRocketryItems.itemSatelliteIdChip)).
+            setRegistryName(new ResourceLocation("advancedrocketry", "itemPlanetIdChip")));
+        toRegister.add(new ShapelessOreRecipe(null, new ItemStack(AdvancedRocketryItems.itemMisc,1,1), charcoal, charcoal, charcoal, charcoal ,charcoal ,charcoal).
+            setRegistryName(new ResourceLocation("advancedrocketry", "itemMisc11")));
+        toRegister.add(new ShapelessOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockLandingPad), new ItemStack(AdvancedRocketryBlocks.blockConcrete), trackingCircuit).
+            setRegistryName(new ResourceLocation("advancedrocketry", "blockLandingPad")));
+        toRegister.add(new ShapelessOreRecipe(null, new ItemStack(AdvancedRocketryItems.itemAsteroidChip), trackingCircuit.copy(), AdvancedRocketryItems.itemDataUnit).
+            setRegistryName(new ResourceLocation("advancedrocketry", "itemAsteroidChip")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockDataPipe, 8), "ggg", " d ", "ggg", 'g', Blocks.GLASS_PANE, 'd', AdvancedRocketryItems.itemDataUnit).
+            setRegistryName(new ResourceLocation("advancedrocketry", "blockDataPipe")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockEnergyPipe, 32), "ggg", " d ", "ggg", 'g', Items.CLAY_BALL, 'd', "stickCopper").
+            setRegistryName(new ResourceLocation("advancedrocketry", "blockEnergyPipe")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockFluidPipe, 32), "ggg", " d ", "ggg", 'g', Items.CLAY_BALL, 'd', "sheetCopper").
+            setRegistryName(new ResourceLocation("advancedrocketry", "blockFluidPipe")));
+      //
+        toRegister.add(new ShapelessOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockDrill), LibVulpesBlocks.blockStructureBlock, Items.IRON_PICKAXE).
+            setRegistryName(new ResourceLocation("advancedrocketry", "blockDrill")));
+        toRegister.add(new ShapelessOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockOrientationController), LibVulpesBlocks.blockStructureBlock, Items.COMPASS, userInterface).
+            setRegistryName(new ResourceLocation("advancedrocketry", "blockOrientationController")));
+        toRegister.add(new ShapelessOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockGravityController), LibVulpesBlocks.blockStructureBlock, Blocks.PISTON, Blocks.REDSTONE_BLOCK).
+            setRegistryName(new ResourceLocation("advancedrocketry", "blockGravityController")));
+        toRegister.add(new ShapelessOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockAltitudeController), LibVulpesBlocks.blockStructureBlock, userInterface, basicCircuit).
+            setRegistryName(new ResourceLocation("advancedrocketry", "blockAltitudeController")));
+      //
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryItems.itemLens), " g ", "g g", 'g', Blocks.GLASS_PANE).
+            setRegistryName(new ResourceLocation("advancedrocketry", "itemLens")));
+        toRegister.add(new ShapelessOreRecipe(null, largeSolarPanel.copy(), smallSolarPanel, smallSolarPanel, smallSolarPanel, smallSolarPanel, smallSolarPanel, smallSolarPanel).
+            setRegistryName(new ResourceLocation("advancedrocketry", "largeSolarPanel")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockMicrowaveReciever), "ggg", "tbc", "aoa", 'g', "plateGold", 't', trackingCircuit, 'b', LibVulpesBlocks.blockStructureBlock, 'c', controlCircuitBoard, 'a', advancedCircuit, 'o', opticalSensor).
+            setRegistryName(new ResourceLocation("advancedrocketry", "blockMicrowaveReciever")));
+        toRegister.add(new ShapedOreRecipe(null, AdvancedRocketryBlocks.blockSolarPanel, "rrr", "gbg", "ppp", 'r' , "dustRedstone", 'g', Items.GLOWSTONE_DUST, 'b', LibVulpesBlocks.blockStructureBlock, 'p', "plateGold").
+            setRegistryName(new ResourceLocation("advancedrocketry", "blockSolarPanel")));
+        toRegister.add(new ShapelessOreRecipe(null, AdvancedRocketryBlocks.blockSolarGenerator, "itemBattery", LibVulpesBlocks.blockForgeOutputPlug, AdvancedRocketryBlocks.blockSolarPanel).
+            setRegistryName(new ResourceLocation("advancedrocketry", "blockSolarGenerator")));
+        toRegister.add(new ShapelessOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockDockingPort), trackingCircuit, new ItemStack(AdvancedRocketryBlocks.blockLoader, 1,1)).
+            setRegistryName(new ResourceLocation("advancedrocketry", "blockDockingPort")));
+      //
+        toRegister.add(new ShapedOreRecipe(null, AdvancedRocketryItems.itemOreScanner, "lwl", "bgb", "   ", 'l', Blocks.LEVER, 'g', userInterface, 'b', "itemBattery", 'w', advancedCircuit).
+            setRegistryName(new ResourceLocation("advancedrocketry", "itemOreScanner")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 4), " c ","sss", "tot", 'c', "stickCopper", 's', "sheetIron", 'o', AdvancedRocketryItems.itemOreScanner, 't', trackingCircuit).
+            setRegistryName(new ResourceLocation("advancedrocketry", "itemSatellitePrimaryFunction14")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockSuitWorkStation), "c","b", 'c', Blocks.CRAFTING_TABLE, 'b', LibVulpesBlocks.blockStructureBlock).
+            setRegistryName(new ResourceLocation("advancedrocketry", "blockSuitWorkStation")));
+        toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryItems.itemSatellite), "sss", "rcr", "sss", 's', "sheetAluminum", 'r', "stickTitanium", 'c', controlCircuitBoard).
+            setRegistryName(new ResourceLocation("advancedrocketry", "itemSatellite")));
+    //            
+    //            
+    //            if(zmaster587.advancedRocketry.api.Configuration.enableLaserDrill) {
+            toRegister.add(new ShapedOreRecipe(null, AdvancedRocketryBlocks.blockSpaceLaser, "ata", "bec", "gpg", 'a', advancedCircuit, 't', trackingCircuit, 'b', LibVulpesItems.itemBattery, 'e', Items.EMERALD, 'c', controlCircuitBoard, 'g', "gearTitanium", 'p', LibVulpesBlocks.blockStructureBlock).
+            setRegistryName(new ResourceLocation("advancedrocketry", "blockSpaceLaser")));
+    //            }
+    //            if(zmaster587.advancedRocketry.api.Configuration.allowTerraforming) {
+            toRegister.add(new ShapedOreRecipe(null, new ItemStack(AdvancedRocketryBlocks.blockAtmosphereTerraformer), "gdg", "lac", "gbg", 'g', "gearTitaniumAluminide", 'd', "crystalDilithium", 'l', liquidIOBoard, 'a', LibVulpesBlocks.blockAdvStructureBlock, 'c', controlCircuitBoard, 'b', battery2x).
+            setRegistryName(new ResourceLocation("advancedrocketry", "blockAtmosphereTerraformer")));
+    //            }
+      //
+    //            //Control boards
+        toRegister.add(new ShapedOreRecipe(null, itemIOBoard, "rvr", "dwd", "dpd", 'r', "dustRedstone", 'v', "gemDiamond", 'd', "dustGold", 'w', "slabWood", 'p', "plateIron").
+            setRegistryName(new ResourceLocation("advancedrocketry", "itemIOBoard")));
+        toRegister.add(new ShapedOreRecipe(null, controlCircuitBoard, "rvr", "dwd", "dpd", 'r', "dustRedstone", 'v', "gemDiamond", 'd', "dustCopper", 'w', "slabWood", 'p', "plateIron").
+            setRegistryName(new ResourceLocation("advancedrocketry", "controlCircuitBoard")));
+        toRegister.add(new ShapedOreRecipe(null, liquidIOBoard, "rvr", "dwd", "dpd", 'r', "dustRedstone", 'v', "gemDiamond", 'd', new ItemStack(Items.DYE, 1, 4), 'w', "slabWood", 'p', "plateIron").
+            setRegistryName(new ResourceLocation("advancedrocketry", "liquidIOBoard")));
         
+        for(net.minecraft.item.crafting.IRecipe recipe: toRegister)
+        {
+            GameData.register_impl(recipe);
+        }
     }
 
 	@EventHandler
@@ -1174,22 +1306,6 @@ public class AdvancedRocketry {
 		proxy.init();
 
 		zmaster587.advancedRocketry.cable.NetworkRegistry.registerFluidNetwork();
-		ItemStack userInterface = new ItemStack(AdvancedRocketryItems.itemMisc, 1,0);
-		ItemStack basicCircuit = new ItemStack(AdvancedRocketryItems.itemIC, 1,0);
-		ItemStack advancedCircuit = new ItemStack(AdvancedRocketryItems.itemIC, 1,2);
-		ItemStack controlCircuitBoard =  new ItemStack(AdvancedRocketryItems.itemIC,1,3);
-		ItemStack itemIOBoard = new ItemStack(AdvancedRocketryItems.itemIC,1,4);
-		ItemStack liquidIOBoard = new ItemStack(AdvancedRocketryItems.itemIC,1,5);
-		ItemStack trackingCircuit = new ItemStack(AdvancedRocketryItems.itemIC,1,1);
-		ItemStack opticalSensor = new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 0);
-		ItemStack massDetector = new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 2);
-		ItemStack biomeChanger = new ItemStack(AdvancedRocketryItems.itemSatellitePrimaryFunction, 1, 5);
-		ItemStack smallSolarPanel =  new ItemStack(AdvancedRocketryItems.itemSatellitePowerSource,1,0); 
-		ItemStack largeSolarPanel = new ItemStack(AdvancedRocketryItems.itemSatellitePowerSource,1,1);
-		ItemStack smallBattery = new ItemStack(LibVulpesItems.itemBattery,1,0);
-		ItemStack battery2x = new ItemStack(LibVulpesItems.itemBattery,1,1);
-		ItemStack superHighPressureTime = new ItemStack(AdvancedRocketryItems.itemPressureTank,1,3);
-		ItemStack charcoal = new ItemStack(Items.COAL,1,1);
 
 		//Register Alloys
 		MaterialRegistry.registerMixedMaterial(new MixedMaterial(TileElectricArcFurnace.class, "oreRutile", new ItemStack[] {MaterialRegistry.getMaterialFromName("Titanium").getProduct(AllowedProducts.getProductByName("INGOT"))}));

--- a/src/main/java/zmaster587/advancedRocketry/achievements/ARAchivements.java
+++ b/src/main/java/zmaster587/advancedRocketry/achievements/ARAchivements.java
@@ -7,53 +7,53 @@ import zmaster587.libVulpes.api.LibVulpesItems;
 import zmaster587.libVulpes.api.material.AllowedProducts;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
-import net.minecraft.stats.Achievement;
-import net.minecraftforge.common.AchievementPage;
+//import net.minecraft.stats.Achievement;
+//import net.minecraftforge.common.AchievementPage;
 
 public class ARAchivements  {
 
-	public static final Achievement moonLanding = new Achievement("achievement.AR.moonLanding", "moonLanding", -5, 1, AdvancedRocketryBlocks.blockMoonTurf, null).initIndependentStat().registerStat();
-	public static final Achievement oneSmallStep = new Achievement("achievement.AR.oneSmallStep", "oneSmallStep", -4, -1, AdvancedRocketryBlocks.blockMoonTurf, moonLanding).setSpecial().registerStat();
-	
-	public static final Achievement dilithiumCrystals = new Achievement("achievement.AR.dilithium", "dilithium", -2, 5, LibVulpes.materialRegistry.getItemStackFromMaterialAndType("Dilithium", AllowedProducts.getProductByName("CRYSTAL")), null).initIndependentStat().registerStat();
-	public static final Achievement warp = new Achievement("achievement.AR.warp", "warp", -2, 3, AdvancedRocketryBlocks.blockWarpCore, dilithiumCrystals).registerStat();
-	//public static final Achievement spaceStation = new Achievement("achievement.AR.spaceStation", "spaceStation", -2, -5, AdvancedRocketryItems.itemSpaceStation, dilithiumCrystals).registerStat();
-	
-	public static final Achievement beerOnTheSun = new Achievement("achievement.beerOnTheSun", "beerOnTheSun", -4, 1, Blocks.TNT, null).initIndependentStat().registerStat();
-	public static final Achievement weReallyWentToTheMoon = new Achievement("achievement.weReallyWentToTheMoon", "weReallyWentToTheMoon", -6, -1, AdvancedRocketryItems.itemSpaceSuit_Boots, moonLanding).registerStat().setSpecial();
-	public static final Achievement suitedUp = new Achievement("achievement.AR.suitedUp", "suitedUp", 0, 5, AdvancedRocketryItems.itemSpaceSuit_Helmet, null).initIndependentStat().registerStat();
-	
-	public static final Achievement givingItAllShesGot = new Achievement("achievement.AR.givingItAllShesGot", "givingItAllShesGot", -2, 1, AdvancedRocketryBlocks.blockWarpCore, dilithiumCrystals).registerStat();
-	public static final Achievement flightOfThePhoenix = new Achievement("achievement.AR.flightOfThePhoenix", "flightOfThePhoenix", -2, -1, AdvancedRocketryBlocks.blockWarpCore, givingItAllShesGot).setSpecial().registerStat();
-	
-	public static final Achievement blockPresser = new Achievement("achievement.AR.flattening", "flattening", 1, -2, Blocks.PISTON, null).registerStat().initIndependentStat();
-	public static final Achievement holographic = new Achievement("achievement.holographic", "holographic", 3, -2, LibVulpesItems.itemHoloProjector, blockPresser).registerStat();
-	public static final Achievement crystalline = new Achievement("achievement.AR.crystalline", "crystalline", 5, 0, AdvancedRocketryBlocks.blockCrystallizer, holographic).registerStat();
-	public static final Achievement rollin = new Achievement("achievement.AR.rollin", "rollin", 5, 2, AdvancedRocketryBlocks.blockRollingMachine, holographic).registerStat();
-	public static final Achievement spinDoctor = new Achievement("achievement.AR.spinDoctor", "spinDoctor", 5, 4, AdvancedRocketryBlocks.blockRollingMachine, holographic).registerStat();
-	public static final Achievement feelTheHeat = new Achievement("achievement.AR.feelTheHeat", "feelTheHeat", 5, 6, AdvancedRocketryBlocks.blockArcFurnace, holographic).registerStat();
-	public static final Achievement electrifying = new Achievement("achievement.AR.electrifying", "electrifying", 5, 8, AdvancedRocketryBlocks.blockElectrolyser, holographic).registerStat();
-	
-	
-	
-	//public static final Achievement gottaGoFast = new Achievement("achiement.gottaGoFast", "gottaGoFast", 0, -2, new ItemStack(AdvancedRocketryItems.itemUpgrade,1,2), suitedUp).registerStat();
-	
-	public static void register() {
-		AchievementPage.registerAchievementPage(new AchievementPage("Advanced Rocketry", moonLanding,
-				dilithiumCrystals,
-				beerOnTheSun,
-				weReallyWentToTheMoon,
-				suitedUp,
-				givingItAllShesGot,
-				crystalline,
-				rollin,
-				warp,
-				oneSmallStep,
-				holographic,
-				flightOfThePhoenix,
-				spinDoctor,
-				feelTheHeat,
-				electrifying,
-				blockPresser));
-	}
+//	public static final Achievement moonLanding = new Achievement("achievement.AR.moonLanding", "moonLanding", -5, 1, AdvancedRocketryBlocks.blockMoonTurf, null).initIndependentStat().registerStat();
+//	public static final Achievement oneSmallStep = new Achievement("achievement.AR.oneSmallStep", "oneSmallStep", -4, -1, AdvancedRocketryBlocks.blockMoonTurf, moonLanding).setSpecial().registerStat();
+//	
+//	public static final Achievement dilithiumCrystals = new Achievement("achievement.AR.dilithium", "dilithium", -2, 5, LibVulpes.materialRegistry.getItemStackFromMaterialAndType("Dilithium", AllowedProducts.getProductByName("CRYSTAL")), null).initIndependentStat().registerStat();
+//	public static final Achievement warp = new Achievement("achievement.AR.warp", "warp", -2, 3, AdvancedRocketryBlocks.blockWarpCore, dilithiumCrystals).registerStat();
+//	//public static final Achievement spaceStation = new Achievement("achievement.AR.spaceStation", "spaceStation", -2, -5, AdvancedRocketryItems.itemSpaceStation, dilithiumCrystals).registerStat();
+//	
+//	public static final Achievement beerOnTheSun = new Achievement("achievement.beerOnTheSun", "beerOnTheSun", -4, 1, Blocks.TNT, null).initIndependentStat().registerStat();
+//	public static final Achievement weReallyWentToTheMoon = new Achievement("achievement.weReallyWentToTheMoon", "weReallyWentToTheMoon", -6, -1, AdvancedRocketryItems.itemSpaceSuit_Boots, moonLanding).registerStat().setSpecial();
+//	public static final Achievement suitedUp = new Achievement("achievement.AR.suitedUp", "suitedUp", 0, 5, AdvancedRocketryItems.itemSpaceSuit_Helmet, null).initIndependentStat().registerStat();
+//	
+//	public static final Achievement givingItAllShesGot = new Achievement("achievement.AR.givingItAllShesGot", "givingItAllShesGot", -2, 1, AdvancedRocketryBlocks.blockWarpCore, dilithiumCrystals).registerStat();
+//	public static final Achievement flightOfThePhoenix = new Achievement("achievement.AR.flightOfThePhoenix", "flightOfThePhoenix", -2, -1, AdvancedRocketryBlocks.blockWarpCore, givingItAllShesGot).setSpecial().registerStat();
+//	
+//	public static final Achievement blockPresser = new Achievement("achievement.AR.flattening", "flattening", 1, -2, Blocks.PISTON, null).registerStat().initIndependentStat();
+//	public static final Achievement holographic = new Achievement("achievement.holographic", "holographic", 3, -2, LibVulpesItems.itemHoloProjector, blockPresser).registerStat();
+//	public static final Achievement crystalline = new Achievement("achievement.AR.crystalline", "crystalline", 5, 0, AdvancedRocketryBlocks.blockCrystallizer, holographic).registerStat();
+//	public static final Achievement rollin = new Achievement("achievement.AR.rollin", "rollin", 5, 2, AdvancedRocketryBlocks.blockRollingMachine, holographic).registerStat();
+//	public static final Achievement spinDoctor = new Achievement("achievement.AR.spinDoctor", "spinDoctor", 5, 4, AdvancedRocketryBlocks.blockRollingMachine, holographic).registerStat();
+//	public static final Achievement feelTheHeat = new Achievement("achievement.AR.feelTheHeat", "feelTheHeat", 5, 6, AdvancedRocketryBlocks.blockArcFurnace, holographic).registerStat();
+//	public static final Achievement electrifying = new Achievement("achievement.AR.electrifying", "electrifying", 5, 8, AdvancedRocketryBlocks.blockElectrolyser, holographic).registerStat();
+//	
+//	
+//	
+//	//public static final Achievement gottaGoFast = new Achievement("achiement.gottaGoFast", "gottaGoFast", 0, -2, new ItemStack(AdvancedRocketryItems.itemUpgrade,1,2), suitedUp).registerStat();
+//	
+//	public static void register() {
+//		AchievementPage.registerAchievementPage(new AchievementPage("Advanced Rocketry", moonLanding,
+//				dilithiumCrystals,
+//				beerOnTheSun,
+//				weReallyWentToTheMoon,
+//				suitedUp,
+//				givingItAllShesGot,
+//				crystalline,
+//				rollin,
+//				warp,
+//				oneSmallStep,
+//				holographic,
+//				flightOfThePhoenix,
+//				spinDoctor,
+//				feelTheHeat,
+//				electrifying,
+//				blockPresser));
+//	}
 }

--- a/src/main/java/zmaster587/advancedRocketry/api/AdvancedRocketryBiomes.java
+++ b/src/main/java/zmaster587/advancedRocketry/api/AdvancedRocketryBiomes.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import net.minecraft.init.Biomes;
 import net.minecraft.world.biome.Biome;
+import net.minecraftforge.registries.IForgeRegistry;
 
 
 /**
@@ -40,9 +41,11 @@ public class AdvancedRocketryBiomes {
 	 * TODO: support id's higher than 255.  
 	 * Any biome registered through vanilla forge does not need to be registered here
 	 * @param biome Biome to register with AdvancedRocketry's Biome registry
+	 * @param iForgeRegistry 
 	 */
-	public void registerBiome(Biome biome) {
+	public void registerBiome(Biome biome, IForgeRegistry<Biome> iForgeRegistry) {
 		registeredBiomes.add(biome);
+		iForgeRegistry.register(biome);
 	}
 
 

--- a/src/main/java/zmaster587/advancedRocketry/armor/ItemSpaceArmor.java
+++ b/src/main/java/zmaster587/advancedRocketry/armor/ItemSpaceArmor.java
@@ -5,20 +5,8 @@ import java.util.List;
 
 import com.mojang.realmsclient.gui.ChatFormatting;
 
-import zmaster587.advancedRocketry.achievements.ARAchivements;
-import zmaster587.advancedRocketry.api.AdvancedRocketryItems;
-import zmaster587.advancedRocketry.api.IAtmosphere;
-import zmaster587.advancedRocketry.api.armor.IFillableArmor;
-import zmaster587.advancedRocketry.api.armor.IProtectiveArmor;
-import zmaster587.advancedRocketry.api.capability.CapabilitySpaceArmor;
-import zmaster587.advancedRocketry.atmosphere.AtmosphereType;
-import zmaster587.advancedRocketry.client.render.armor.RenderJetPack;
-import zmaster587.libVulpes.api.IArmorComponent;
-import zmaster587.libVulpes.api.IJetPack;
-import zmaster587.libVulpes.api.IModularArmor;
-import zmaster587.libVulpes.util.EmbeddedInventory;
-import zmaster587.libVulpes.util.IconResource;
 import net.minecraft.client.model.ModelBiped;
+import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -37,6 +25,18 @@ import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.Constants.NBT;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import zmaster587.advancedRocketry.api.AdvancedRocketryItems;
+import zmaster587.advancedRocketry.api.IAtmosphere;
+import zmaster587.advancedRocketry.api.armor.IFillableArmor;
+import zmaster587.advancedRocketry.api.armor.IProtectiveArmor;
+import zmaster587.advancedRocketry.api.capability.CapabilitySpaceArmor;
+import zmaster587.advancedRocketry.atmosphere.AtmosphereType;
+import zmaster587.advancedRocketry.client.render.armor.RenderJetPack;
+import zmaster587.libVulpes.api.IArmorComponent;
+import zmaster587.libVulpes.api.IJetPack;
+import zmaster587.libVulpes.api.IModularArmor;
+import zmaster587.libVulpes.util.EmbeddedInventory;
+import zmaster587.libVulpes.util.IconResource;
 /**
  * Space Armor
  * Any class that extends this will gain the ability to store oxygen and will protect players from the vacuum atmosphere type
@@ -58,8 +58,8 @@ public class ItemSpaceArmor extends ItemArmor implements ISpecialArmor, ICapabil
 	}
 
 	@Override
-	public void addInformation(ItemStack stack, EntityPlayer p_77624_2_,
-			List list, boolean p_77624_4_) {
+	public void addInformation(ItemStack stack, World p_77624_2_,
+			List list, ITooltipFlag p_77624_4_) {
 		super.addInformation(stack, p_77624_2_, list, p_77624_4_);
 
 		list.add("Modules:");
@@ -155,8 +155,8 @@ public class ItemSpaceArmor extends ItemArmor implements ISpecialArmor, ICapabil
 		ItemStack leg = player.getItemStackFromSlot(EntityEquipmentSlot.LEGS);
 		ItemStack chest = player.getItemStackFromSlot(EntityEquipmentSlot.CHEST);
 		ItemStack helm = player.getItemStackFromSlot(EntityEquipmentSlot.HEAD);
-		if(!feet.isEmpty() && feet.getItem() instanceof ItemSpaceArmor && !leg.isEmpty() && leg.getItem() instanceof ItemSpaceArmor && !chest.isEmpty() && chest.getItem() instanceof ItemSpaceArmor && !helm.isEmpty() && helm.getItem() instanceof ItemSpaceArmor)
-			player.addStat(ARAchivements.suitedUp);
+//		if(!feet.isEmpty() && feet.getItem() instanceof ItemSpaceArmor && !leg.isEmpty() && leg.getItem() instanceof ItemSpaceArmor && !chest.isEmpty() && chest.getItem() instanceof ItemSpaceArmor && !helm.isEmpty() && helm.getItem() instanceof ItemSpaceArmor)
+//			player.addStat(ARAchivements.suitedUp);TODO Advancement Trigger
 	}
 
 	@Override

--- a/src/main/java/zmaster587/advancedRocketry/asm/AdvancedRocketryPlugin.java
+++ b/src/main/java/zmaster587/advancedRocketry/asm/AdvancedRocketryPlugin.java
@@ -7,7 +7,7 @@ import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.MCVersion;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin.TransformerExclusions;
 
 @TransformerExclusions(value = {"zmaster587.advancedRocketry.asm.ClassTransformer"})
-@MCVersion("1.11.2")
+@MCVersion("1.12.1")
 public class AdvancedRocketryPlugin implements IFMLLoadingPlugin {
 
 	public AdvancedRocketryPlugin() {

--- a/src/main/java/zmaster587/advancedRocketry/asm/ClassTransformer.java
+++ b/src/main/java/zmaster587/advancedRocketry/asm/ClassTransformer.java
@@ -62,7 +62,7 @@ public class ClassTransformer implements IClassTransformer {
 	private static final String METHOD_KEY_ONUPDATE = "net.minecraft.client.entity.Entity.onUpdate";
 	private static final String METHOD_KEY_GETLOOKVEC = "net.minecraft.entity.EntityLivingBase.getLookVec";
 	private static final String METHOD_KEY_DORENDER  = "net.minecraft.client.renderer.entity.RenderLivingEntity.doRender";
-	private static final String METHOD_KEY_MOVEENTITYWITHHEADING = "net.minecraft.entity.EntityLivingBase.moveEntityWithHeading";
+//	private static final String METHOD_KEY_TRAVEL = "net.minecraft.entity.EntityLivingBase.travel";
 	private static final String METHOD_KEY_MOVEFLYING = "net.minecraft.entity.Entity.moveFlying";
 	private static final String METHOD_KEY_SETBLOCKSTATE = CLASS_KEY_WORLD + ".setBlockState";
 	private static final String METHOD_KEY_SETBLOCKMETADATAWITHNOTIFY = CLASS_KEY_WORLD + ".setBlockMetadataWithNotify";
@@ -130,7 +130,7 @@ public class ClassTransformer implements IClassTransformer {
 		//entryMap.put(METHOD_KEY_SETPOSITION, new SimpleEntry<String, String>("setPosition",""));
 		//entryMap.put(METHOD_KEY_GETLOOKVEC, new SimpleEntry<String, String>("getLook", ""));
 		//entryMap.put(METHOD_KEY_DORENDER, new SimpleEntry<String, String>("doRender",""));
-		entryMap.put(METHOD_KEY_MOVEENTITYWITHHEADING, new SimpleEntry<String, String>("moveEntityWithHeading","g"));
+		//entryMap.put(METHOD_KEY_TRAVEL, new SimpleEntry<String, String>("travel","g"));
 		//entryMap.put(METHOD_KEY_MOVEFLYING, new SimpleEntry<String, String>("moveFlying",""));
 		//entryMap.put(METHOD_KEY_ONLIVINGUPDATE, new SimpleEntry<String, String>("onLivingUpdate","e"));
 		entryMap.put(METHOD_KEY_ONUPDATE, new SimpleEntry<String, String>("onUpdate","A_"));
@@ -834,47 +834,6 @@ public class ClassTransformer implements IClassTransformer {
 				nodeAdd.add(new VarInsnNode(Opcodes.ALOAD, 0));
 				nodeAdd.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "zmaster587/advancedRocketry/util/GravityHandler", "applyGravity", "(L" + getName(CLASS_KEY_ENTITY) + ";)V", false));
 				onUpdate.instructions.insert(pos, nodeAdd);
-			}
-
-			return finishInjection(cn);
-		}
-
-		if(changedName.equals(getName(CLASS_KEY_ENTITYLIVEINGBASE))) {
-			ClassNode cn = startInjection(bytes);
-
-			MethodNode moveEntityWithHeading = getMethod(cn, getName(METHOD_KEY_MOVEENTITYWITHHEADING), "(FF)V");
-
-			if(moveEntityWithHeading != null) {
-				final InsnList nodeAdd = new InsnList();
-				AbstractInsnNode pos = null;
-				List<AbstractInsnNode> removeNodes = new LinkedList<AbstractInsnNode>();
-				int numGoto = 4;
-
-				for(int i = moveEntityWithHeading.instructions.size() - 1; i >= 0; i--) {
-					AbstractInsnNode ain = moveEntityWithHeading.instructions.get(i);
-					if(ain.getOpcode() == Opcodes.GOTO && --numGoto == 0) {
-						pos = ain;
-
-
-						while(moveEntityWithHeading.instructions.get(--i).getOpcode() != Opcodes.ALOAD);
-
-						pos = moveEntityWithHeading.instructions.get(i-1);
-						ain = moveEntityWithHeading.instructions.get(i);
-						do {
-							moveEntityWithHeading.instructions.remove(ain);
-							removeNodes.add(ain);
-							ain = moveEntityWithHeading.instructions.get(i);
-						} while(ain.getOpcode() != Opcodes.PUTFIELD);
-
-						moveEntityWithHeading.instructions.remove(ain);
-
-						break;
-					}
-				}
-
-				nodeAdd.add(new VarInsnNode(Opcodes.ALOAD, 0));
-				nodeAdd.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "zmaster587/advancedRocketry/util/GravityHandler", "applyGravity", "(L" + getName(CLASS_KEY_ENTITY) + ";)V", false));
-				moveEntityWithHeading.instructions.insert(pos, nodeAdd);
 			}
 
 			return finishInjection(cn);

--- a/src/main/java/zmaster587/advancedRocketry/backwardCompat/Face.java
+++ b/src/main/java/zmaster587/advancedRocketry/backwardCompat/Face.java
@@ -1,7 +1,7 @@
 package zmaster587.advancedRocketry.backwardCompat;
 
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.util.math.Vec3d;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -14,13 +14,13 @@ public class Face
     public TextureCoordinate[] textureCoordinates;
 
     @SideOnly(Side.CLIENT)
-    public void addFaceForRender(VertexBuffer tessellator)
+    public void addFaceForRender(BufferBuilder tessellator)
     {
         addFaceForRender(tessellator, 0.0005F);
     }
 
     @SideOnly(Side.CLIENT)
-    public void addFaceForRender(VertexBuffer tessellator, float textureOffset)
+    public void addFaceForRender(BufferBuilder tessellator, float textureOffset)
     {
         if (faceNormal == null)
         {
@@ -82,6 +82,6 @@ public class Face
 
         normalVector = v1.crossProduct(v2).normalize();
 
-        return new Vertex((float) normalVector.xCoord, (float) normalVector.yCoord, (float) normalVector.zCoord);
+        return new Vertex((float) normalVector.x, (float) normalVector.y, (float) normalVector.z);
     }
 }

--- a/src/main/java/zmaster587/advancedRocketry/backwardCompat/GroupObject.java
+++ b/src/main/java/zmaster587/advancedRocketry/backwardCompat/GroupObject.java
@@ -3,7 +3,7 @@ package zmaster587.advancedRocketry.backwardCompat;
 import java.util.ArrayList;
 
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraftforge.fml.relauncher.Side;
@@ -36,7 +36,7 @@ public class GroupObject
     {
         if (faces.size() > 0)
         {
-            VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+            BufferBuilder buffer = Tessellator.getInstance().getBuffer();
             buffer.begin(glDrawingMode, drawMode);
             render(buffer);
             Tessellator.getInstance().draw();
@@ -44,7 +44,7 @@ public class GroupObject
     }
 
     @SideOnly(Side.CLIENT)
-    public void render(VertexBuffer tessellator)
+    public void render(BufferBuilder tessellator)
     {
         if (faces.size() > 0)
         {

--- a/src/main/java/zmaster587/advancedRocketry/backwardCompat/WavefrontObject.java
+++ b/src/main/java/zmaster587/advancedRocketry/backwardCompat/WavefrontObject.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.client.resources.IResource;
@@ -178,7 +178,7 @@ public class WavefrontObject
     @SideOnly(Side.CLIENT)
     public void renderAll()
     {
-        VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+        BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 
         if (currentGroupObject != null)
         {
@@ -195,7 +195,7 @@ public class WavefrontObject
     }
 
     @SideOnly(Side.CLIENT)
-    public void tessellateAll(VertexBuffer tessellator)
+    public void tessellateAll(BufferBuilder tessellator)
     {
         for (GroupObject groupObject : groupObjects)
         {
@@ -219,7 +219,7 @@ public class WavefrontObject
     }
 
     @SideOnly(Side.CLIENT)
-    public void tessellateOnly(VertexBuffer buffer, String... groupNames) {
+    public void tessellateOnly(BufferBuilder buffer, String... groupNames) {
         for (GroupObject groupObject : groupObjects)
         {
             for (String groupName : groupNames)
@@ -245,7 +245,7 @@ public class WavefrontObject
     }
 
     @SideOnly(Side.CLIENT)
-    public void tessellatePart(VertexBuffer buffer, String partName) {
+    public void tessellatePart(BufferBuilder buffer, String partName) {
         for (GroupObject groupObject : groupObjects)
         {
             if (partName.equalsIgnoreCase(groupObject.name))
@@ -276,7 +276,7 @@ public class WavefrontObject
     }
 
     @SideOnly(Side.CLIENT)
-    public void tessellateAllExcept(VertexBuffer buffer, String... excludedGroupNames)
+    public void tessellateAllExcept(BufferBuilder buffer, String... excludedGroupNames)
     {
         boolean exclude;
         for (GroupObject groupObject : groupObjects)

--- a/src/main/java/zmaster587/advancedRocketry/block/BlockCrystal.java
+++ b/src/main/java/zmaster587/advancedRocketry/block/BlockCrystal.java
@@ -72,10 +72,10 @@ public class BlockCrystal extends Block implements INamedMetaBlock {
     }
     
 	@Override
-	public void getSubBlocks(Item item, CreativeTabs tab,
+	public void getSubBlocks(CreativeTabs tab,
 			NonNullList<ItemStack> list) {
 		for(int i = 0; i < colors.length; i++) {
-			list.add(new ItemStack(item, 1, i));
+			list.add(new ItemStack(this, 1, i));
 		}
 	}
 	

--- a/src/main/java/zmaster587/advancedRocketry/block/BlockPlanetSoil.java
+++ b/src/main/java/zmaster587/advancedRocketry/block/BlockPlanetSoil.java
@@ -19,8 +19,8 @@ public class BlockPlanetSoil extends Block {
 		return this;
 	}
 	
-	@Override
-	public MapColor getMapColor(IBlockState state) {
-		return extraMapColor == null ? super.getMapColor(state) : extraMapColor;
-	}
+//	@Override//TODO colour for soil?
+//	public MapColor getMapColor(IBlockState state) {
+//		return extraMapColor == null ? super.getMapColor(state) : extraMapColor;
+//	}
 }

--- a/src/main/java/zmaster587/advancedRocketry/block/BlockPressurizedFluidTank.java
+++ b/src/main/java/zmaster587/advancedRocketry/block/BlockPressurizedFluidTank.java
@@ -93,7 +93,7 @@ public class BlockPressurizedFluidTank extends Block {
 
 			if (itemstack.hasTagCompound())
 			{
-				entityitem.getEntityItem().setTagCompound((NBTTagCompound)itemstack.getTagCompound().copy());
+				entityitem.getItem().setTagCompound((NBTTagCompound)itemstack.getTagCompound().copy());
 			}
 			world.spawnEntity(entityitem);
 		}

--- a/src/main/java/zmaster587/advancedRocketry/block/BlockSuitWorkstation.java
+++ b/src/main/java/zmaster587/advancedRocketry/block/BlockSuitWorkstation.java
@@ -53,7 +53,7 @@ public class BlockSuitWorkstation extends BlockTile {
 
 					if (itemstack.hasTagCompound())
 					{
-						entityitem.getEntityItem().setTagCompound((NBTTagCompound)itemstack.getTagCompound().copy());
+						entityitem.getItem().setTagCompound((NBTTagCompound)itemstack.getTagCompound().copy());
 					}
 				}
 			}

--- a/src/main/java/zmaster587/advancedRocketry/block/multiblock/BlockARHatch.java
+++ b/src/main/java/zmaster587/advancedRocketry/block/multiblock/BlockARHatch.java
@@ -31,15 +31,15 @@ public class BlockARHatch extends BlockHatch {
 	}
 	
 	@Override
-	public void getSubBlocks(Item item, CreativeTabs tab,
+	public void getSubBlocks(CreativeTabs tab,
 			NonNullList<ItemStack> list) {
-		list.add(new ItemStack(item, 1, 0));
-		list.add(new ItemStack(item, 1, 1));
-		list.add(new ItemStack(item, 1, 2));
-		list.add(new ItemStack(item, 1, 3));
-		list.add(new ItemStack(item, 1, 4));
-		list.add(new ItemStack(item, 1, 5));
-		list.add(new ItemStack(item, 1, 6));
+		list.add(new ItemStack(this, 1, 0));
+		list.add(new ItemStack(this, 1, 1));
+		list.add(new ItemStack(this, 1, 2));
+		list.add(new ItemStack(this, 1, 3));
+		list.add(new ItemStack(this, 1, 4));
+		list.add(new ItemStack(this, 1, 5));
+		list.add(new ItemStack(this, 1, 6));
 	}
 	
 	@Override

--- a/src/main/java/zmaster587/advancedRocketry/capability/CapabilityProtectiveArmor.java
+++ b/src/main/java/zmaster587/advancedRocketry/capability/CapabilityProtectiveArmor.java
@@ -1,6 +1,7 @@
 package zmaster587.advancedRocketry.capability;
 
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
@@ -18,12 +19,12 @@ public class CapabilityProtectiveArmor {
 
 	
 	@SubscribeEvent
-	public void attachCapabilities(AttachCapabilitiesEvent.Item evt)
+	public void attachCapabilities(AttachCapabilitiesEvent<ItemStack> evt)
 	{
 		if (evt.getCapabilities().containsKey(KEY)) {
 			return;
 		}
-		Item item = evt.getItem();
+		Item item = evt.getObject().getItem();
 		if (item instanceof ItemSpaceArmor) {
 			evt.addCapability(KEY, (ICapabilityProvider) item);
 		}

--- a/src/main/java/zmaster587/advancedRocketry/client/ClientProxy.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/ClientProxy.java
@@ -422,14 +422,14 @@ public class ClientProxy extends CommonProxy {
 
 	@Override
 	public void spawnLaser(Entity entity, Vec3d toPos) {
-		FxLaser fx = new FxLaser(entity.world, toPos.xCoord, toPos.yCoord, toPos.zCoord, entity);
+		FxLaser fx = new FxLaser(entity.world, toPos.x, toPos.y, toPos.z, entity);
 		Minecraft.getMinecraft().effectRenderer.addEffect(fx);
 
-		FxLaserHeat fx2 = new FxLaserHeat(entity.world,  toPos.xCoord, toPos.yCoord, toPos.zCoord, 0.02f);
+		FxLaserHeat fx2 = new FxLaserHeat(entity.world,  toPos.x, toPos.y, toPos.z, 0.02f);
 		Minecraft.getMinecraft().effectRenderer.addEffect(fx2);
 		
 		for(int i = 0; i < 4; i++) {
-			FxLaserSpark fx3 = new FxLaserSpark(entity.world,  toPos.xCoord, toPos.yCoord, toPos.zCoord, 
+			FxLaserSpark fx3 = new FxLaserSpark(entity.world,  toPos.x, toPos.y, toPos.z, 
 					.125 - entity.world.rand.nextFloat()/4f, .125 - entity.world.rand.nextFloat()/4f, .125 - entity.world.rand.nextFloat()/4f, .5f);
 			Minecraft.getMinecraft().effectRenderer.addEffect(fx3);
 		}

--- a/src/main/java/zmaster587/advancedRocketry/client/model/ModelRocket.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/model/ModelRocket.java
@@ -3,9 +3,8 @@ package zmaster587.advancedRocketry.client.model;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
+import java.util.Optional;
+import java.util.function.Function;
 
 import net.minecraft.client.renderer.block.model.IBakedModel;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
@@ -64,7 +63,7 @@ public class ModelRocket implements IModel {
 		@Override
 		public Optional<TRSRTransformation> apply(
 				Optional<? extends IModelPart> part) {
-			return Optional.absent();
+			return Optional.empty();
 		}
 		
 	}

--- a/src/main/java/zmaster587/advancedRocketry/client/render/RenderLaser.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/RenderLaser.java
@@ -9,7 +9,7 @@ import net.minecraft.client.particle.Particle;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
@@ -39,7 +39,7 @@ public class RenderLaser extends Render implements IRenderFactory<EntityLaserNod
 
 		GL11.glPushMatrix();
 		GL11.glTranslated(x, y, z);
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 		GL11.glDisable(GL11.GL_LIGHTING);
 		GL11.glDisable(GL11.GL_FOG);
 		GL11.glEnable(GL11.GL_BLEND);
@@ -99,7 +99,7 @@ public class RenderLaser extends Render implements IRenderFactory<EntityLaserNod
 
 		GL11.glPushMatrix();
 		GL11.glTranslated(x, y, z);
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 		GL11.glDisable(GL11.GL_LIGHTING);
 		GL11.glDisable(GL11.GL_FOG);
 		GL11.glEnable(GL11.GL_BLEND);

--- a/src/main/java/zmaster587/advancedRocketry/client/render/RenderLaserTile.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/RenderLaserTile.java
@@ -5,7 +5,7 @@ import org.lwjgl.opengl.GL11;
 import zmaster587.advancedRocketry.tile.multiblock.TileSpaceLaser;
 
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.tileentity.TileEntity;
@@ -13,15 +13,15 @@ import net.minecraft.tileentity.TileEntity;
 public class RenderLaserTile extends TileEntitySpecialRenderer {
 
 	@Override
-	public void renderTileEntityAt(TileEntity tileentity, double x, double y,
-			double z, float f, int damage) {
+	public void render(TileEntity tileentity, double x, double y,
+			double z, float f, int damage, float a) {
 
 		if(!((TileSpaceLaser)tileentity).isRunning())
 			return;
 		
 		GL11.glPushMatrix();
 		GL11.glTranslated(x, y, z);
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 		GL11.glDisable(GL11.GL_LIGHTING);
 		GL11.glDisable(GL11.GL_FOG);
 		GL11.glEnable(GL11.GL_BLEND);

--- a/src/main/java/zmaster587/advancedRocketry/client/render/RenderTank.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/RenderTank.java
@@ -21,8 +21,8 @@ import net.minecraftforge.fluids.capability.IFluidHandler;
 public class RenderTank extends TileEntitySpecialRenderer {
 
 	@Override
-	public void renderTileEntityAt(TileEntity tile, double x,
-			double y, double z, float f, int damage) {
+	public void render(TileEntity tile, double x,
+			double y, double z, float f, int damage, float a) {
 
 		IFluidHandler fluidTile = (IFluidHandler)tile;
 		FluidStack fluid = fluidTile.getTankProperties()[0].getContents();

--- a/src/main/java/zmaster587/advancedRocketry/client/render/RendererPhantomBlock.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/RendererPhantomBlock.java
@@ -12,7 +12,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.BlockRendererDispatcher;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.block.model.IBakedModel;
 import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
@@ -28,8 +28,8 @@ public class RendererPhantomBlock extends TileEntitySpecialRenderer {
 	private static BlockRendererDispatcher renderBlocks = Minecraft.getMinecraft().getBlockRendererDispatcher();
 
 	@Override
-	public void renderTileEntityAt(TileEntity tile, double x,
-			double y, double z, float t, int damage) {
+	public void render(TileEntity tile, double x,
+			double y, double z, float t, int damage, float a) {
 
 		renderBlocks = Minecraft.getMinecraft().getBlockRendererDispatcher();
 		TilePlaceholder tileGhost = (TilePlaceholder)tile;
@@ -56,7 +56,7 @@ public class RendererPhantomBlock extends TileEntitySpecialRenderer {
 		GL11.glEnable(GL11.GL_BLEND);
 		GL11.glBlendFunc(GL11.GL_ONE_MINUS_SRC_COLOR, GL11.GL_SRC_ALPHA);
 		Tessellator tess = Tessellator.getInstance();
-		VertexBuffer buffer =tess.getBuffer();
+		BufferBuilder buffer =tess.getBuffer();
 
 		buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.BLOCK);
 		IBakedModel model = renderBlocks.getModelForState(state);
@@ -77,9 +77,9 @@ public class RendererPhantomBlock extends TileEntitySpecialRenderer {
 
 					ItemStack stack = tile.getWorld().getBlockState(tile.getPos()).getBlock().getPickBlock(tile.getWorld().getBlockState(tile.getPos()), movingObjPos, Minecraft.getMinecraft().world, tile.getPos(), Minecraft.getMinecraft().player);
 					if(stack == null)
-						RenderHelper.renderTag(Minecraft.getMinecraft().player.getDistanceSq(movingObjPos.hitVec.xCoord, movingObjPos.hitVec.yCoord, movingObjPos.hitVec.zCoord), "THIS IS AN ERROR, CONTACT THE DEV!!!", x,y,z, 10);
+						RenderHelper.renderTag(Minecraft.getMinecraft().player.getDistanceSq(movingObjPos.hitVec.x, movingObjPos.hitVec.y, movingObjPos.hitVec.z), "THIS IS AN ERROR, CONTACT THE DEV!!!", x,y,z, 10);
 					else
-						RenderHelper.renderTag(Minecraft.getMinecraft().player.getDistanceSq(movingObjPos.hitVec.xCoord, movingObjPos.hitVec.yCoord, movingObjPos.hitVec.zCoord), stack.getDisplayName(), x+ 0.5f,y,z+ 0.5f, 10);
+						RenderHelper.renderTag(Minecraft.getMinecraft().player.getDistanceSq(movingObjPos.hitVec.x, movingObjPos.hitVec.y, movingObjPos.hitVec.z), stack.getDisplayName(), x+ 0.5f,y,z+ 0.5f, 10);
 				}
 			} catch (NullPointerException e) {
 				//silence you fool

--- a/src/main/java/zmaster587/advancedRocketry/client/render/RendererPipe.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/RendererPipe.java
@@ -7,7 +7,7 @@ import zmaster587.libVulpes.render.RenderHelper;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.tileentity.TileEntity;
@@ -26,10 +26,10 @@ public class RendererPipe extends TileEntitySpecialRenderer {
 
 
 	@Override
-	public void renderTileEntityAt(TileEntity tile, double x, double y,
-			double z, float f, int damage) {
+	public void render(TileEntity tile, double x, double y,
+			double z, float f, int damage, float a) {
 		
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 
 		GL11.glPushMatrix();
 

--- a/src/main/java/zmaster587/advancedRocketry/client/render/RendererRocket.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/RendererRocket.java
@@ -12,7 +12,7 @@ import net.minecraft.client.renderer.GLAllocation;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.texture.TextureMap;
@@ -43,7 +43,7 @@ public class RendererRocket extends Render implements IRenderFactory<EntityRocke
 		StorageChunk storage  = ((EntityRocket)entity).storage;
 
 
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 
 		if(storage == null || !storage.finalized)
 			return;
@@ -137,9 +137,9 @@ public class RendererRocket extends Render implements IRenderFactory<EntityRocke
 
 		//Render tile entities if applicable
 		for(TileEntity tile : storage.getTileEntityList()) {
-			TileEntitySpecialRenderer renderer = (TileEntitySpecialRenderer)TileEntityRendererDispatcher.instance.mapSpecialRenderers.get(tile.getClass());
+			TileEntitySpecialRenderer renderer = (TileEntitySpecialRenderer)TileEntityRendererDispatcher.instance.renderers.get(tile.getClass());
 			if(renderer != null ) {
-				TileEntityRendererDispatcher.instance.renderTileEntityAt(tile, tile.getPos().getX(), tile.getPos().getY(), tile.getPos().getZ(), f1);
+				TileEntityRendererDispatcher.instance.render(tile, tile.getPos().getX(), tile.getPos().getY(), tile.getPos().getZ(), f1);
 				
 				//renderer.renderTileEntity(tile, tile.getPos().getX(), tile.getPos().getY(), tile.getPos().getZ(), f1, 0);
 			}

--- a/src/main/java/zmaster587/advancedRocketry/client/render/RendererRocketBuilder.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/RendererRocketBuilder.java
@@ -6,7 +6,7 @@ import zmaster587.advancedRocketry.tile.TileRocketBuilder;
 import zmaster587.libVulpes.render.RenderHelper;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.tileentity.TileEntity;
@@ -21,8 +21,8 @@ public class RendererRocketBuilder extends TileEntitySpecialRenderer {
 	private ResourceLocation round_h = new ResourceLocation("advancedrocketry:textures/models/round_h.png");
 	
 	@Override
-	public void renderTileEntityAt(TileEntity tile, double x,
-			double y, double z, float f, int dist) {
+	public void render(TileEntity tile, double x,
+			double y, double z, float f, int dist, float a) {
 
 
 
@@ -41,7 +41,7 @@ public class RendererRocketBuilder extends TileEntitySpecialRenderer {
 			double zSize = bb.maxZ - bb.minZ+1;
 			
 			double yLocation = -(bb.maxY - bb.minY + 1.12)*renderTile.getNormallizedProgress();
-			VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+			BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 			
 			double xMin = xOffset;
 			double yMin = yOffset + yLocation;

--- a/src/main/java/zmaster587/advancedRocketry/client/render/entity/RenderButtonUIEntity.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/entity/RenderButtonUIEntity.java
@@ -6,7 +6,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;

--- a/src/main/java/zmaster587/advancedRocketry/client/render/entity/RenderElevatorCapsule.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/entity/RenderElevatorCapsule.java
@@ -6,7 +6,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.culling.ICamera;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;

--- a/src/main/java/zmaster587/advancedRocketry/client/render/entity/RenderPlanetUIEntity.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/entity/RenderPlanetUIEntity.java
@@ -6,7 +6,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
@@ -93,7 +93,7 @@ public class RenderPlanetUIEntity extends Render<EntityUIPlanet> implements IRen
 		GlStateManager.color(.1f, .1f, .1f,0.75f);
 		sphere.renderAll();
 
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 
 		if(properties.hasRings) {
 			//Rotate for rings
@@ -143,7 +143,7 @@ public class RenderPlanetUIEntity extends Render<EntityUIPlanet> implements IRen
 		GL11.glPushMatrix();
 		OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 0, 0);
 
-		VertexBuffer buf = Tessellator.getInstance().getBuffer();
+		BufferBuilder buf = Tessellator.getInstance().getBuffer();
 		GL11.glDisable(GL11.GL_TEXTURE_2D);
 
 		float myTime = ((entity.world.getTotalWorldTime() & 0xF)/16f);
@@ -197,7 +197,7 @@ public class RenderPlanetUIEntity extends Render<EntityUIPlanet> implements IRen
 			//GL11.glDepthMask(false);
 			GL11.glDisable(GL11.GL_DEPTH_TEST);
 
-			RenderHelper.setupPlayerFacingMatrix(Minecraft.getMinecraft().player.getDistanceSq(hitObj.hitVec.xCoord, hitObj.hitVec.yCoord, hitObj.hitVec.zCoord), 0, 0, 0);
+			RenderHelper.setupPlayerFacingMatrix(Minecraft.getMinecraft().player.getDistanceSq(hitObj.hitVec.z, hitObj.hitVec.y, hitObj.hitVec.x), 0, 0, 0);
 			buffer = Tessellator.getInstance().getBuffer();
 
 			//Draw Mass indicator
@@ -223,8 +223,8 @@ public class RenderPlanetUIEntity extends Render<EntityUIPlanet> implements IRen
 			GL11.glEnable(GL11.GL_DEPTH_TEST);
 			//GL11.glDepthMask(true);
 			RenderHelper.cleanupPlayerFacingMatrix();
-			RenderHelper.renderTag(Minecraft.getMinecraft().player.getDistanceSq(hitObj.hitVec.xCoord, hitObj.hitVec.yCoord, hitObj.hitVec.zCoord), properties.getName(), 0, .9, 0, 5);
-			RenderHelper.renderTag(Minecraft.getMinecraft().player.getDistanceSq(hitObj.hitVec.xCoord, hitObj.hitVec.yCoord, hitObj.hitVec.zCoord), "NumMoons: " + properties.getChildPlanets().size(), 0, .6, 0, 5);
+			RenderHelper.renderTag(Minecraft.getMinecraft().player.getDistanceSq(hitObj.hitVec.z, hitObj.hitVec.y, hitObj.hitVec.x), properties.getName(), 0, .9, 0, 5);
+			RenderHelper.renderTag(Minecraft.getMinecraft().player.getDistanceSq(hitObj.hitVec.z, hitObj.hitVec.y, hitObj.hitVec.x), "NumMoons: " + properties.getChildPlanets().size(), 0, .6, 0, 5);
 
 			GL11.glPopMatrix();
 		}
@@ -236,7 +236,7 @@ public class RenderPlanetUIEntity extends Render<EntityUIPlanet> implements IRen
 		OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 0, 0);
 	}
 
-	protected void renderMassIndicator(VertexBuffer buffer, float percent) {
+	protected void renderMassIndicator(BufferBuilder buffer, float percent) {
 		buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);
 
 		float maxUV = (1-percent)*0.5f;
@@ -245,7 +245,7 @@ public class RenderPlanetUIEntity extends Render<EntityUIPlanet> implements IRen
 		Tessellator.getInstance().draw();
 	}
 
-	protected void renderATMIndicator(VertexBuffer buffer, float percent) {
+	protected void renderATMIndicator(BufferBuilder buffer, float percent) {
 		buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);
 
 		float maxUV = (1-percent)*0.406f + .578f;
@@ -254,7 +254,7 @@ public class RenderPlanetUIEntity extends Render<EntityUIPlanet> implements IRen
 		Tessellator.getInstance().draw();
 	}
 
-	protected void renderTemperatureIndicator(VertexBuffer buffer, float percent) {
+	protected void renderTemperatureIndicator(BufferBuilder buffer, float percent) {
 		buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);
 
 		float maxUV = (1-percent)*0.406f + .578f;

--- a/src/main/java/zmaster587/advancedRocketry/client/render/entity/RenderStarUIEntity.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/entity/RenderStarUIEntity.java
@@ -6,7 +6,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
@@ -57,7 +57,7 @@ public class RenderStarUIEntity extends Render<EntityUIStar> implements IRenderF
 		RenderHelper.setupPlayerFacingMatrix(Minecraft.getMinecraft().player.getDistanceSqToEntity(entity), 0,-.45,0);
 		Minecraft.getMinecraft().renderEngine.bindTexture(TextureResources.locationSunNew);
 		
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 		
 		GL11.glDisable(GL11.GL_LIGHTING);
 		GL11.glEnable(GL11.GL_BLEND);
@@ -81,7 +81,7 @@ public class RenderStarUIEntity extends Render<EntityUIStar> implements IRenderF
 		GL11.glScaled(.1, .1, .1);
 		OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 0, 0);
 
-		VertexBuffer buf = Tessellator.getInstance().getBuffer();
+		BufferBuilder buf = Tessellator.getInstance().getBuffer();
 		GL11.glDisable(GL11.GL_TEXTURE_2D);
 
 		float myTime = ((entity.world.getTotalWorldTime() & 0xF)/16f);
@@ -135,7 +135,7 @@ public class RenderStarUIEntity extends Render<EntityUIStar> implements IRenderF
 			//GL11.glDepthMask(false);
 			GL11.glDisable(GL11.GL_DEPTH_TEST);
 			
-			RenderHelper.setupPlayerFacingMatrix(Minecraft.getMinecraft().player.getDistanceSq(hitObj.hitVec.xCoord, hitObj.hitVec.yCoord, hitObj.hitVec.zCoord), 0, 0, 0);
+			RenderHelper.setupPlayerFacingMatrix(Minecraft.getMinecraft().player.getDistanceSq(hitObj.hitVec.x, hitObj.hitVec.y, hitObj.hitVec.z), 0, 0, 0);
 			buffer = Tessellator.getInstance().getBuffer();
 			
 			//Draw Mass indicator
@@ -154,8 +154,8 @@ public class RenderStarUIEntity extends Render<EntityUIStar> implements IRenderF
 			GL11.glEnable(GL11.GL_DEPTH_TEST);
 			//GL11.glDepthMask(true);
 			RenderHelper.cleanupPlayerFacingMatrix();
-			RenderHelper.renderTag(Minecraft.getMinecraft().player.getDistanceSq(hitObj.hitVec.xCoord, hitObj.hitVec.yCoord, hitObj.hitVec.zCoord), body.getName(), 0, .9, 0, 5);
-			RenderHelper.renderTag(Minecraft.getMinecraft().player.getDistanceSq(hitObj.hitVec.xCoord, hitObj.hitVec.yCoord, hitObj.hitVec.zCoord), "Num Planets: " + body.getNumPlanets(), 0, .6, 0, 5);
+			RenderHelper.renderTag(Minecraft.getMinecraft().player.getDistanceSq(hitObj.hitVec.x, hitObj.hitVec.y, hitObj.hitVec.z), body.getName(), 0, .9, 0, 5);
+			RenderHelper.renderTag(Minecraft.getMinecraft().player.getDistanceSq(hitObj.hitVec.x, hitObj.hitVec.y, hitObj.hitVec.z), "Num Planets: " + body.getNumPlanets(), 0, .6, 0, 5);
 
 			GL11.glPopMatrix();
 		}
@@ -167,7 +167,7 @@ public class RenderStarUIEntity extends Render<EntityUIStar> implements IRenderF
 		OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 0, 0);
 	}
 	
-	protected void renderMassIndicator(VertexBuffer buffer, float percent) {
+	protected void renderMassIndicator(BufferBuilder buffer, float percent) {
 		buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);
 		
 		float maxUV = (1-percent)*0.5f;
@@ -176,7 +176,7 @@ public class RenderStarUIEntity extends Render<EntityUIStar> implements IRenderF
 		Tessellator.getInstance().draw();
 	}
 	
-	protected void renderATMIndicator(VertexBuffer buffer, float percent) {
+	protected void renderATMIndicator(BufferBuilder buffer, float percent) {
 		buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);
 		
 		float maxUV = (1-percent)*0.406f + .578f;
@@ -185,7 +185,7 @@ public class RenderStarUIEntity extends Render<EntityUIStar> implements IRenderF
 		Tessellator.getInstance().draw();
 	}
 	
-	protected void renderTemperatureIndicator(VertexBuffer buffer, float percent) {
+	protected void renderTemperatureIndicator(BufferBuilder buffer, float percent) {
 		buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);
 		
 		float maxUV = (1-percent)*0.406f + .578f;

--- a/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RenderBeacon.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RenderBeacon.java
@@ -31,8 +31,8 @@ public class RenderBeacon extends TileEntitySpecialRenderer {
 	}
 
 	@Override
-	public void renderTileEntityAt(TileEntity tile, double x,
-			double y, double z, float f, int damage) {
+	public void render(TileEntity tile, double x,
+			double y, double z, float f, int damage, float a) {
 		TileMultiPowerConsumer multiBlockTile = (TileMultiPowerConsumer)tile;
 
 		if(!multiBlockTile.canRender())

--- a/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RenderBiomeScanner.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RenderBiomeScanner.java
@@ -1,7 +1,7 @@
 package zmaster587.advancedRocketry.client.render.multiblocks;
 
 import net.minecraft.client.renderer.OpenGlHelper;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
@@ -29,14 +29,8 @@ public class RenderBiomeScanner extends TileEntitySpecialRenderer {
 	}
 	
 	@Override
-	public void renderTileEntityFast(TileEntity te, double x, double y,
-			double z, float partialTicks, int destroyStage, VertexBuffer buffer) {
-		super.renderTileEntityFast(te, x, y, z, partialTicks, destroyStage, buffer);
-	}
-	
-	@Override
-	public void renderTileEntityAt(TileEntity tile, double x, double y, double z,
-			float partialTicks, int destroyStage) {
+	public void render(TileEntity tile, double x, double y, double z,
+			float partialTicks, int destroyStage, float a) {
 		TileMultiPowerConsumer multiBlockTile = (TileMultiPowerConsumer)tile;
 
 		if(!multiBlockTile.canRender())

--- a/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RenderGravityMachine.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RenderGravityMachine.java
@@ -33,8 +33,8 @@ public class RenderGravityMachine extends TileEntitySpecialRenderer {
 	}
 	
 	@Override
-	public void renderTileEntityAt(TileEntity tile, double x,
-			double y, double z, float f, int damage) {
+	public void render(TileEntity tile, double x,
+			double y, double z, float f, int damage, float a) {
 		TileGravityController multiBlockTile = (TileGravityController)tile;
 
 		if(!multiBlockTile.canRender())

--- a/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RenderLaser.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RenderLaser.java
@@ -28,8 +28,8 @@ public class RenderLaser extends TileEntitySpecialRenderer {
 	}
 	
 	@Override
-	public void renderTileEntityAt(TileEntity tile, double x,
-			double y, double z, float f, int damage) {
+	public void render(TileEntity tile, double x,
+			double y, double z, float f, int damage, float a) {
 		TileMultiBlock multiBlockTile = (TileMultiBlock)tile;
 
 		if(!multiBlockTile.canRender())

--- a/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RenderPlanetAnalyser.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RenderPlanetAnalyser.java
@@ -28,8 +28,8 @@ public class RenderPlanetAnalyser extends TileEntitySpecialRenderer {
 	}
 	
 	@Override
-	public void renderTileEntityAt(TileEntity tile, double x,
-			double y, double z, float f, int distance) {
+	public void render(TileEntity tile, double x,
+			double y, double z, float f, int distance, float a) {
 		TileMultiPowerConsumer multiBlockTile = (TileMultiPowerConsumer)tile;
 
 		if(!multiBlockTile.canRender())

--- a/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RenderTerraformerAtm.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RenderTerraformerAtm.java
@@ -30,8 +30,8 @@ public class RenderTerraformerAtm extends TileEntitySpecialRenderer {
 	}
 	
 	@Override
-	public void renderTileEntityAt(TileEntity tile, double x,
-			double y, double z, float f, int damage) {
+	public void render(TileEntity tile, double x,
+			double y, double z, float f, int damage, float a) {
 		TileMultiBlock multiBlockTile = (TileMultiBlock)tile;
 
 		if(!multiBlockTile.canRender())

--- a/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererChemicalReactor.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererChemicalReactor.java
@@ -28,8 +28,8 @@ public class RendererChemicalReactor  extends TileEntitySpecialRenderer {
 	}
 	
 	@Override
-	public void renderTileEntityAt(TileEntity tile, double x, double y, double z,
-			float partialTicks, int destroyStage) {
+	public void render(TileEntity tile, double x, double y, double z,
+			float partialTicks, int destroyStage, float a) {
 		
 		TileChemicalReactor multiBlockTile = (TileChemicalReactor)tile;
 

--- a/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererCrystallizer.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererCrystallizer.java
@@ -46,8 +46,8 @@ public class RendererCrystallizer extends TileEntitySpecialRenderer {
 	}
 
 	@Override
-	public void renderTileEntityAt(TileEntity tile, double x,
-			double y, double z, float f,  int destroyStage) {
+	public void render(TileEntity tile, double x,
+			double y, double z, float f,  int destroyStage, float a) {
 		TileMultiblockMachine multiBlockTile = (TileMultiblockMachine)tile;
 
 		if(!multiBlockTile.canRender())
@@ -73,7 +73,7 @@ public class RendererCrystallizer extends TileEntitySpecialRenderer {
 				ItemStack stack = outputList.get(0);
 				EntityItem entity = new EntityItem(tile.getWorld());
 
-				entity.setEntityItemStack(stack);
+				entity.setItem(stack);
 				entity.hoverStart = 0;
 
 				int rotation = (int)(tile.getWorld().getTotalWorldTime() % 360);

--- a/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererCuttingMachine.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererCuttingMachine.java
@@ -39,8 +39,8 @@ public class RendererCuttingMachine extends TileEntitySpecialRenderer {
 	}
 
 	@Override
-	public void renderTileEntityAt(TileEntity tile, double x, double y, double z,
-			float partialTicks, int destroyStage) {
+	public void render(TileEntity tile, double x, double y, double z,
+			float partialTicks, int destroyStage, float a) {
 		TileMultiblockMachine multiBlockTile = (TileMultiblockMachine)tile;
 
 		if(!multiBlockTile.canRender())

--- a/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererElectrolyser.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererElectrolyser.java
@@ -4,7 +4,7 @@ package zmaster587.advancedRocketry.client.render.multiblocks;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.tileentity.TileEntity;
@@ -36,8 +36,8 @@ public class RendererElectrolyser extends TileEntitySpecialRenderer {
 	}
 	
 	@Override
-	public void renderTileEntityAt(TileEntity tile, double x,
-			double y, double z, float f, int destroyState) {
+	public void render(TileEntity tile, double x,
+			double y, double z, float f, int destroyState, float a) {
 		TileMultiblockMachine multiBlockTile = (TileMultiblockMachine)tile;
 
 		if(!multiBlockTile.canRender())
@@ -56,7 +56,7 @@ public class RendererElectrolyser extends TileEntitySpecialRenderer {
 		//Lightning effect
 
 		if(multiBlockTile.isRunning()) {
-			VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+			BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 
 			double width = 0.01;
 

--- a/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererLathe.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererLathe.java
@@ -35,8 +35,8 @@ public class RendererLathe extends TileEntitySpecialRenderer {
 	}
 
 	@Override
-	public void renderTileEntityAt(TileEntity tile, double x,
-			double y, double z, float f, int damage) {
+	public void render(TileEntity tile, double x,
+			double y, double z, float f, int damage, float a) {
 		TileMultiblockMachine multiBlockTile = (TileMultiblockMachine)tile;
 
 		if(!multiBlockTile.canRender())

--- a/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererMicrowaveReciever.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererMicrowaveReciever.java
@@ -4,7 +4,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.tileentity.TileEntity;
@@ -23,8 +23,8 @@ public class RendererMicrowaveReciever extends TileEntitySpecialRenderer {
 	ResourceLocation panelSide = new ResourceLocation("advancedrocketry:textures/blocks/panelSide.png");
 
 	@Override
-	public void renderTileEntityAt(TileEntity tile, double x,
-			double y, double z, float f, int damage) {
+	public void render(TileEntity tile, double x,
+			double y, double z, float f, int damage, float a) {
 		TileMicrowaveReciever multiBlockTile = (TileMicrowaveReciever)tile;
 
 		if(!multiBlockTile.canRender())
@@ -32,7 +32,7 @@ public class RendererMicrowaveReciever extends TileEntitySpecialRenderer {
 
 		GL11.glPushMatrix();
 		GL11.glTranslated(x, y, z);
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 		//Initial setup
 		bindTexture(texture);
 		

--- a/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererObservatory.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererObservatory.java
@@ -29,8 +29,8 @@ public class RendererObservatory  extends TileEntitySpecialRenderer {
 
 
 	@Override
-	public void renderTileEntityAt(TileEntity tile, double x,
-			double y, double z, float f, int damage) {
+	public void render(TileEntity tile, double x,
+			double y, double z, float f, int damage, float a) {
 		TileObservatory multiBlockTile = (TileObservatory)tile;
 
 		if(!multiBlockTile.canRender())

--- a/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererPrecisionAssembler.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererPrecisionAssembler.java
@@ -43,8 +43,8 @@ public class RendererPrecisionAssembler extends TileEntitySpecialRenderer {
 	}
 
 	@Override
-	public void renderTileEntityAt(TileEntity tile, double x,
-			double y, double z, float f, int damage) {
+	public void render(TileEntity tile, double x,
+			double y, double z, float f, int damage, float a) {
 
 		TileMultiblockMachine multiBlockTile = (TileMultiblockMachine)tile;
 
@@ -72,7 +72,7 @@ public class RendererPrecisionAssembler extends TileEntitySpecialRenderer {
 				ItemStack stack = outputList.get(0);
 				EntityItem entity = new EntityItem(tile.getWorld());
 				
-				entity.setEntityItemStack(stack);
+				entity.setItem(stack);
 				entity.hoverStart = 0;
 				
 				GL11.glPushMatrix();

--- a/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererRailgun.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererRailgun.java
@@ -30,8 +30,8 @@ public class RendererRailgun extends TileEntitySpecialRenderer {
 	}
 	
 	@Override
-	public void renderTileEntityAt(TileEntity tile, double x,
-			double y, double z, float f, int damage) {
+	public void render(TileEntity tile, double x,
+			double y, double z, float f, int damage, float a) {
 		TileRailgun multiBlockTile = (TileRailgun)tile;
 
 		if(!multiBlockTile.canRender())

--- a/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererRollingMachine.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererRollingMachine.java
@@ -34,8 +34,8 @@ public class RendererRollingMachine extends TileEntitySpecialRenderer {
 	}
 
 	@Override
-	public void renderTileEntityAt(TileEntity tile, double x,
-			double y, double z, float f, int damage) {
+	public void render(TileEntity tile, double x,
+			double y, double z, float f, int damage, float a) {
 		TileMultiblockMachine multiBlockTile = (TileMultiblockMachine)tile;
 
 		if(!multiBlockTile.canRender())

--- a/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererSpaceElevator.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererSpaceElevator.java
@@ -2,7 +2,7 @@ package zmaster587.advancedRocketry.client.render.multiblocks;
 
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.Entity;
@@ -36,8 +36,8 @@ public class RendererSpaceElevator extends TileEntitySpecialRenderer {
 	}
 	
 	@Override
-	public void renderTileEntityAt(TileEntity tile, double x,
-			double y, double z, float f, int damage) {
+	public void render(TileEntity tile, double x,
+			double y, double z, float f, int damage, float a) {
 		TileSpaceElevator multiBlockTile = (TileSpaceElevator)tile;
 
 		if(!multiBlockTile.canRender())
@@ -64,7 +64,7 @@ public class RendererSpaceElevator extends TileEntitySpecialRenderer {
 		//Render Beads
 		GL11.glPushMatrix();
 		GL11.glTranslated(x + multiBlockTile.getLandingLocationX() - multiBlockTile.getPos().getX(), y, z + multiBlockTile.getLandingLocationZ() - multiBlockTile.getPos().getZ());
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 		GL11.glDisable(GL11.GL_LIGHTING);
 		GL11.glDisable(GL11.GL_FOG);
 		GL11.glEnable(GL11.GL_BLEND);

--- a/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererWarpCore.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RendererWarpCore.java
@@ -18,7 +18,7 @@ import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.RenderItem;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
@@ -44,8 +44,8 @@ public class RendererWarpCore extends TileEntitySpecialRenderer {
 	}
 
 	@Override
-	public void renderTileEntityAt(TileEntity tile, double x,
-			double y, double z, float f, int damage) {
+	public void render(TileEntity tile, double x,
+			double y, double z, float f, int damage, float a) {
 		TileMultiBlock multiBlockTile = (TileMultiBlock)tile;
 
 		if(!multiBlockTile.canRender())
@@ -71,7 +71,7 @@ public class RendererWarpCore extends TileEntitySpecialRenderer {
 		GlStateManager.color(1f, 0.4f, 0.4f, 0.8f);
 		GL11.glPushMatrix();
 		
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 		
 		buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);
 		RenderHelper.renderCubeWithUV(buffer, -0.1f, 1, -0.1f, 0.1f, 2, 0.1f, 0, 1, 0, 1);

--- a/src/main/java/zmaster587/advancedRocketry/client/render/planet/RenderPlanetarySky.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/planet/RenderPlanetarySky.java
@@ -26,7 +26,7 @@ import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
@@ -67,7 +67,7 @@ public class RenderPlanetarySky extends IRenderHandler {
 		this.renderStars();
 		GL11.glEndList();
 		GL11.glPopMatrix();
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 		this.glSkyList = this.starGLCallList + 1;
 		GL11.glNewList(this.glSkyList, GL11.GL_COMPILE);
 		byte b2 = 64;
@@ -115,7 +115,7 @@ public class RenderPlanetarySky extends IRenderHandler {
 	private void renderStars()
 	{
 		Random random = new Random(10842L);
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 		buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
 
 		for (int i = 0; i < 2000; ++i)
@@ -249,9 +249,9 @@ public class RenderPlanetarySky extends IRenderHandler {
 
 		GL11.glDisable(GL11.GL_TEXTURE_2D);
 		Vec3d vec3 = Minecraft.getMinecraft().world.getSkyColor(this.mc.getRenderViewEntity(), partialTicks);
-		float f1 = (float)vec3.xCoord;
-		float f2 = (float)vec3.yCoord;
-		float f3 = (float)vec3.zCoord;
+		float f1 = (float)vec3.x;
+		float f2 = (float)vec3.y;
+		float f3 = (float)vec3.z;
 		float f6;
 
 		if (this.mc.gameSettings.anaglyph)
@@ -270,7 +270,7 @@ public class RenderPlanetarySky extends IRenderHandler {
 		f3 *= atmosphere;
 
 		GL11.glColor3f(f1, f2, f3);
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 
 		GL11.glDepthMask(false);
 		GL11.glEnable(GL11.GL_FOG);
@@ -576,7 +576,7 @@ public class RenderPlanetarySky extends IRenderHandler {
 		GL11.glPopMatrix();
 		GL11.glDisable(GL11.GL_TEXTURE_2D);
 		GL11.glColor3f(0.0F, 0.0F, 0.0F);
-		double d0 = this.mc.player.getPositionEyes(partialTicks).yCoord - mc.world.getHorizon();
+		double d0 = this.mc.player.getPositionEyes(partialTicks).y - mc.world.getHorizon();
 
 		if (d0 < 0.0D)
 		{
@@ -649,11 +649,11 @@ public class RenderPlanetarySky extends IRenderHandler {
 		return EnumFacing.EAST;
 	}
 
-	protected void renderPlanet(VertexBuffer buffer, ResourceLocation icon, float planetOrbitalDistance, float alphaMultiplier, double shadowAngle, boolean hasAtmosphere, float[] skyColor, float[] ringColor, boolean gasGiant, boolean hasRing) {
+	protected void renderPlanet(BufferBuilder buffer, ResourceLocation icon, float planetOrbitalDistance, float alphaMultiplier, double shadowAngle, boolean hasAtmosphere, float[] skyColor, float[] ringColor, boolean gasGiant, boolean hasRing) {
 		renderPlanet2(buffer, icon, 0, 0, -100, 10f*(200-planetOrbitalDistance)/100f, alphaMultiplier, shadowAngle, hasAtmosphere, skyColor, ringColor, gasGiant, hasRing);
 	}
 
-	protected void renderPlanet2(VertexBuffer buffer, ResourceLocation icon, int locationX, int locationY, double zLevel, float size, float alphaMultiplier, double shadowAngle, boolean hasAtmosphere, float[] skyColor, float[] ringColor, boolean gasGiant, boolean hasRing) {
+	protected void renderPlanet2(BufferBuilder buffer, ResourceLocation icon, int locationX, int locationY, double zLevel, float size, float alphaMultiplier, double shadowAngle, boolean hasAtmosphere, float[] skyColor, float[] ringColor, boolean gasGiant, boolean hasRing) {
 		renderPlanetPubHelper(buffer, icon, locationX, locationY, zLevel, size, alphaMultiplier, shadowAngle, hasAtmosphere, skyColor, ringColor, gasGiant, hasRing);
 	}
 
@@ -670,7 +670,7 @@ public class RenderPlanetarySky extends IRenderHandler {
 		return axis;
 	}
 
-	public static void renderPlanetPubHelper(VertexBuffer buffer, ResourceLocation icon, int locationX, int locationY, double zLevel, float size, float alphaMultiplier, double shadowAngle, boolean hasAtmosphere, float[] skyColor, float[] ringColor, boolean gasGiant, boolean hasRing) {
+	public static void renderPlanetPubHelper(BufferBuilder buffer, ResourceLocation icon, int locationX, int locationY, double zLevel, float size, float alphaMultiplier, double shadowAngle, boolean hasAtmosphere, float[] skyColor, float[] ringColor, boolean gasGiant, boolean hasRing) {
 		GL11.glEnable(GL11.GL_BLEND);
 
 		//int k = mc.theWorld.getMoonPhase();
@@ -786,9 +786,9 @@ public class RenderPlanetarySky extends IRenderHandler {
 		GlStateManager.color(1f, 1f, 1f, 1f);
 	}
 
-	private void drawStar(VertexBuffer buffer, int solarOrbitalDistance, float sunSize, Vec3d sunColor, float multiplier) {
+	private void drawStar(BufferBuilder buffer, int solarOrbitalDistance, float sunSize, Vec3d sunColor, float multiplier) {
 		//Set sun color and distance
-		GlStateManager.color((float)sunColor.xCoord, (float)sunColor.yCoord , (float)sunColor.zCoord ,Math.min((multiplier)*2f,1f));
+		GlStateManager.color((float)sunColor.x, (float)sunColor.y , (float)sunColor.z ,Math.min((multiplier)*2f,1f));
 		buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);	
 		float f10 = sunSize*30f*(202-solarOrbitalDistance)/100f;
 		//multiplier = 2;

--- a/src/main/java/zmaster587/advancedRocketry/client/render/planet/RenderSpaceSky.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/planet/RenderSpaceSky.java
@@ -10,7 +10,7 @@ import zmaster587.libVulpes.util.Vector3F;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
@@ -27,7 +27,7 @@ public class RenderSpaceSky extends RenderPlanetarySky {
 	Minecraft mc = Minecraft.getMinecraft();
 
 	@Override
-	public void renderPlanet2(VertexBuffer buffer, ResourceLocation icon, int locationX, int locationY, double zLevel, float planetOrbitalDistance, float alphaMultiplier, double angle, boolean hasAtmosphere, float[] atmColor, float[] ringColor, boolean isGasgiant, boolean hasRings) {
+	public void renderPlanet2(BufferBuilder buffer, ResourceLocation icon, int locationX, int locationY, double zLevel, float planetOrbitalDistance, float alphaMultiplier, double angle, boolean hasAtmosphere, float[] atmColor, float[] ringColor, boolean isGasgiant, boolean hasRings) {
 
 		
 		ISpaceObject object = SpaceObjectManager.getSpaceManager().getSpaceStationFromBlockCoords(mc.player.getPosition());

--- a/src/main/java/zmaster587/advancedRocketry/command/WorldCommand.java
+++ b/src/main/java/zmaster587/advancedRocketry/command/WorldCommand.java
@@ -261,7 +261,7 @@ public class WorldCommand implements ICommand {
 					sender.sendMessage(new TextComponentString("Invalid player name: " + string[1]));
 				}
 				else {
-					player.getServer().getPlayerList().transferPlayerToDimension((EntityPlayerMP) player,  me.world.provider.getDimension() , new TeleporterNoPortal(me.getServer().worldServerForDimension(me.world.provider.getDimension())));
+					player.getServer().getPlayerList().transferPlayerToDimension((EntityPlayerMP) player,  me.world.provider.getDimension() , new TeleporterNoPortal(me.getServer().getWorld(me.world.provider.getDimension())));
 					player.setPosition(me.posX, me.posY, me.posZ);
 				}
 			}

--- a/src/main/java/zmaster587/advancedRocketry/dimension/DimensionProperties.java
+++ b/src/main/java/zmaster587/advancedRocketry/dimension/DimensionProperties.java
@@ -1375,7 +1375,7 @@ public class DimensionProperties implements Cloneable, IDimensionProperties {
 	 */
 	public float[] getFogColorAtHeight(double y, Vec3d fogColor) {
 		float atmDensity = getAtmosphereDensityAtHeight(y);
-		return new float[] { (float) (atmDensity * fogColor.xCoord), (float) (atmDensity * fogColor.yCoord), (float) (atmDensity * fogColor.zCoord) };
+		return new float[] { (float) (atmDensity * fogColor.x), (float) (atmDensity * fogColor.y), (float) (atmDensity * fogColor.z) };
 	}
 
 	/**

--- a/src/main/java/zmaster587/advancedRocketry/entity/EntityElevatorCapsule.java
+++ b/src/main/java/zmaster587/advancedRocketry/entity/EntityElevatorCapsule.java
@@ -193,13 +193,13 @@ public class EntityElevatorCapsule extends Entity implements INetworkEntity {
 			this.world.profiler.startSection("changeDimension");
 			MinecraftServer minecraftserver = this.getServer();
 			int i = this.dimension;
-			WorldServer worldserver = minecraftserver.worldServerForDimension(i);
-			WorldServer worldserver1 = minecraftserver.worldServerForDimension(dimensionIn);
+			WorldServer worldserver = minecraftserver.getWorld(i);
+			WorldServer worldserver1 = minecraftserver.getWorld(dimensionIn);
 			this.dimension = dimensionIn;
 
 			if (i == 1 && dimensionIn == 1)
 			{
-				worldserver1 = minecraftserver.worldServerForDimension(0);
+				worldserver1 = minecraftserver.getWorld(0);
 				this.dimension = 0;
 			}
 
@@ -280,7 +280,7 @@ public class EntityElevatorCapsule extends Entity implements INetworkEntity {
 
 	@Override
 	public AxisAlignedBB getRenderBoundingBox() {
-		return getEntityBoundingBox().addCoord(posX, 2000, posZ);
+		return getEntityBoundingBox().expand(posX, 2000, posZ);
 	}
 
 	@Override

--- a/src/main/java/zmaster587/advancedRocketry/entity/EntityItemAbducted.java
+++ b/src/main/java/zmaster587/advancedRocketry/entity/EntityItemAbducted.java
@@ -17,7 +17,7 @@ import net.minecraft.world.World;
 
 public class EntityItemAbducted extends Entity {
 
-	private static final DataParameter<ItemStack> ITEM = EntityDataManager.<ItemStack>createKey(EntityItem.class, DataSerializers.OPTIONAL_ITEM_STACK);
+	private static final DataParameter<ItemStack> ITEM = EntityDataManager.<ItemStack>createKey(EntityItem.class, DataSerializers.ITEM_STACK);
 	public int lifespan = 6000;
 	public int age = 0;
 	EntityItem itemEntity;

--- a/src/main/java/zmaster587/advancedRocketry/entity/EntityRocket.java
+++ b/src/main/java/zmaster587/advancedRocketry/entity/EntityRocket.java
@@ -1,7 +1,5 @@
 package zmaster587.advancedRocketry.entity;
 
-import io.netty.buffer.ByteBuf;
-
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -11,6 +9,7 @@ import java.util.ListIterator;
 
 import javax.annotation.Nullable;
 
+import io.netty.buffer.ByteBuf;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GLAllocation;
@@ -43,7 +42,6 @@ import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import zmaster587.advancedRocketry.AdvancedRocketry;
-import zmaster587.advancedRocketry.achievements.ARAchivements;
 import zmaster587.advancedRocketry.api.AdvancedRocketryItems;
 import zmaster587.advancedRocketry.api.Configuration;
 import zmaster587.advancedRocketry.api.EntityRocketBase;
@@ -837,9 +835,9 @@ public class EntityRocket extends EntityRocketBase implements INetworkEntity, IM
 				if(DimensionManager.getInstance().getDimensionProperties(destinationDimId).getName().equals("Luna")) {
 					for(Entity player : this.getPassengers()) {
 						if(player instanceof EntityPlayer) {
-							((EntityPlayer)player).addStat(ARAchivements.moonLanding);
-							if(!DimensionManager.hasReachedMoon)
-								((EntityPlayer)player).addStat(ARAchivements.oneSmallStep);
+//							((EntityPlayer)player).addStat(ARAchivements.moonLanding);
+//							if(!DimensionManager.hasReachedMoon)//TODO advancment triggers here.
+//								((EntityPlayer)player).addStat(ARAchivements.oneSmallStep);
 						}
 					}
 					DimensionManager.hasReachedMoon = true;
@@ -1047,13 +1045,13 @@ public class EntityRocket extends EntityRocketBase implements INetworkEntity, IM
 			this.world.profiler.startSection("changeDimension");
 			MinecraftServer minecraftserver = this.getServer();
 			int i = this.dimension;
-			WorldServer worldserver = minecraftserver.worldServerForDimension(i);
-			WorldServer worldserver1 = minecraftserver.worldServerForDimension(dimensionIn);
+			WorldServer worldserver = minecraftserver.getWorld(i);
+			WorldServer worldserver1 = minecraftserver.getWorld(dimensionIn);
 			this.dimension = dimensionIn;
 
 			if (i == 1 && dimensionIn == 1)
 			{
-				worldserver1 = minecraftserver.worldServerForDimension(0);
+				worldserver1 = minecraftserver.getWorld(0);
 				this.dimension = 0;
 			}
 

--- a/src/main/java/zmaster587/advancedRocketry/entity/FxSkyLaser.java
+++ b/src/main/java/zmaster587/advancedRocketry/entity/FxSkyLaser.java
@@ -7,7 +7,7 @@ import zmaster587.advancedRocketry.client.render.RenderLaser;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.Particle;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
@@ -29,7 +29,7 @@ public class FxSkyLaser extends Particle {
 	}
 	
 	@Override
-	public void renderParticle(VertexBuffer worldRendererIn, Entity entityIn,
+	public void renderParticle(BufferBuilder worldRendererIn, Entity entityIn,
 			float partialTicks, float rotationX, float rotationZ,
 			float rotationYZ, float rotationXY, float rotationXZ) {
 		//Will this break rendering?

--- a/src/main/java/zmaster587/advancedRocketry/entity/fx/FxElectricArc.java
+++ b/src/main/java/zmaster587/advancedRocketry/entity/fx/FxElectricArc.java
@@ -6,7 +6,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.Particle;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
@@ -32,7 +32,7 @@ public class FxElectricArc  extends Particle {
 	}
 
 	@Override
-	public void renderParticle(VertexBuffer worldRendererIn, Entity entityIn,
+	public void renderParticle(BufferBuilder worldRendererIn, Entity entityIn,
 			float x1,
 			float rotX, float rotXZ, float rotZ,
 			float rotYZ, float rotXY) {
@@ -50,7 +50,7 @@ public class FxElectricArc  extends Particle {
 		render(worldRendererIn,x,y,z, f10, rotX, rotXZ, rotZ, rotYZ, rotXY, 0);
 	}
 
-	private void render(VertexBuffer tess, float x, float y, float z, float scale,
+	private void render(BufferBuilder tess, float x, float y, float z, float scale,
 			float rotX, float rotXZ, float rotZ,
 			float rotYZ, float rotXY, float shearX) {
 		

--- a/src/main/java/zmaster587/advancedRocketry/entity/fx/FxGravityEffect.java
+++ b/src/main/java/zmaster587/advancedRocketry/entity/fx/FxGravityEffect.java
@@ -5,7 +5,7 @@ import org.lwjgl.opengl.GL11;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.Particle;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.ResourceLocation;
@@ -37,7 +37,7 @@ public class FxGravityEffect extends Particle {
 	}
 
 	@Override
-	public void renderParticle(VertexBuffer worldRendererIn, Entity entityIn,
+	public void renderParticle(BufferBuilder worldRendererIn, Entity entityIn,
 			float partialTicks, float rotationX, float rotationZ,
 			float rotationYZ, float rotationXY, float rotationXZ) {
 		//super.renderParticle(worldRendererIn, entityIn, partialTicks, rotationX,

--- a/src/main/java/zmaster587/advancedRocketry/entity/fx/FxLaser.java
+++ b/src/main/java/zmaster587/advancedRocketry/entity/fx/FxLaser.java
@@ -8,7 +8,7 @@ import net.minecraft.client.particle.Particle;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
@@ -31,7 +31,7 @@ public class FxLaser extends Particle {
 	}
 
 	@Override
-	public void renderParticle(VertexBuffer worldRendererIn, Entity entityIn,
+	public void renderParticle(BufferBuilder worldRendererIn, Entity entityIn,
 			float partialTicks, float rotationX, float rotationZ,
 			float rotationYZ, float rotationXY, float rotationXZ) {
 		//worldRendererIn.finishDrawing();
@@ -57,7 +57,7 @@ public class FxLaser extends Particle {
 		OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE, 0, 0);
 		OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240.0F, 240.0F);
 		
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 		buffer.begin(GL11.GL_LINES, DefaultVertexFormats.POSITION);
 		GL11.glLineWidth(5);
 		GlStateManager.color(0.8f, 0.2f, 0.2f, .4f);

--- a/src/main/java/zmaster587/advancedRocketry/entity/fx/FxLaserHeat.java
+++ b/src/main/java/zmaster587/advancedRocketry/entity/fx/FxLaserHeat.java
@@ -4,7 +4,7 @@ import net.minecraft.client.particle.Particle;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.Entity;
 import net.minecraft.world.World;
@@ -30,7 +30,7 @@ public class FxLaserHeat extends Particle {
 	}
 
 	@Override
-	public void renderParticle(VertexBuffer worldRendererIn, Entity entityIn,
+	public void renderParticle(BufferBuilder worldRendererIn, Entity entityIn,
 			float partialTicks, float rotationX, float rotationZ,
 			float rotationYZ, float rotationXY, float rotationXZ) {
 		//worldRendererIn.finishDrawing();
@@ -49,7 +49,7 @@ public class FxLaserHeat extends Particle {
 		OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE, 0, 0);
 		OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240.0F, 240.0F);
 		
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 		buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_NORMAL);
 		GlStateManager.color(0.8f, 0.2f, 0.2f, particleAlpha);
 		

--- a/src/main/java/zmaster587/advancedRocketry/entity/fx/FxLaserSpark.java
+++ b/src/main/java/zmaster587/advancedRocketry/entity/fx/FxLaserSpark.java
@@ -5,7 +5,7 @@ import net.minecraft.client.particle.Particle;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.math.MathHelper;
@@ -32,7 +32,7 @@ public class FxLaserSpark extends Particle {
 	}
 
 	@Override
-	public void renderParticle(VertexBuffer worldRendererIn, Entity entityIn,
+	public void renderParticle(BufferBuilder worldRendererIn, Entity entityIn,
 			float partialTicks, float rotationX, float rotationZ,
 			float rotationYZ, float rotationXY, float rotationXZ) {
 		//worldRendererIn.finishDrawing();
@@ -51,7 +51,7 @@ public class FxLaserSpark extends Particle {
 		OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE, 0, 0);
 		OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240.0F, 240.0F);
 		
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 		buffer.begin(GL11.GL_LINES, DefaultVertexFormats.POSITION);
 		GL11.glLineWidth(1);
 		GlStateManager.color(0.8f, 0.2f, 0.2f, particleAlpha);

--- a/src/main/java/zmaster587/advancedRocketry/entity/fx/InverseTrailFx.java
+++ b/src/main/java/zmaster587/advancedRocketry/entity/fx/InverseTrailFx.java
@@ -4,7 +4,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.Particle;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.ResourceLocation;
@@ -38,7 +38,7 @@ public class InverseTrailFx extends Particle {
 	}
 
 	@Override
-	public void renderParticle(VertexBuffer worldRendererIn, Entity entityIn,
+	public void renderParticle(BufferBuilder worldRendererIn, Entity entityIn,
 			float partialTicks, float rotationX, float rotationZ,
 			float rotationYZ, float rotationXY, float rotationXZ) {
 		//super.renderParticle(worldRendererIn, entityIn, partialTicks, rotationX,

--- a/src/main/java/zmaster587/advancedRocketry/entity/fx/RocketFx.java
+++ b/src/main/java/zmaster587/advancedRocketry/entity/fx/RocketFx.java
@@ -5,7 +5,7 @@ import org.lwjgl.opengl.GL11;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.Particle;
 import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
@@ -46,7 +46,7 @@ public class RocketFx extends Particle {
 	}
 	
 	@Override
-	public void renderParticle(VertexBuffer worldRendererIn, Entity entityIn,
+	public void renderParticle(BufferBuilder worldRendererIn, Entity entityIn,
 			float partialTicks, float rotationX, float rotationZ,
 			float rotationYZ, float rotationXY, float rotationXZ) {
         float f = (float)this.particleTextureIndexX / 16.0F;
@@ -75,9 +75,9 @@ public class RocketFx extends Particle {
         {
             float f8 = this.particleAngle + (this.particleAngle - this.prevParticleAngle) * partialTicks;
             float f9 = MathHelper.cos(f8 * 0.5F);
-            float f10 = MathHelper.sin(f8 * 0.5F) * (float)cameraViewDir.xCoord;
-            float f11 = MathHelper.sin(f8 * 0.5F) * (float)cameraViewDir.yCoord;
-            float f12 = MathHelper.sin(f8 * 0.5F) * (float)cameraViewDir.zCoord;
+            float f10 = MathHelper.sin(f8 * 0.5F) * (float)cameraViewDir.x;
+            float f11 = MathHelper.sin(f8 * 0.5F) * (float)cameraViewDir.y;
+            float f12 = MathHelper.sin(f8 * 0.5F) * (float)cameraViewDir.z;
             Vec3d vec3d = new Vec3d((double)f10, (double)f11, (double)f12);
 
             for (int l = 0; l < 4; ++l)
@@ -94,10 +94,10 @@ public class RocketFx extends Particle {
         f2 = 0f;
         f3 = 1f;
         
-        worldRendererIn.pos((double)f5 + avec3d[0].xCoord, (double)f6 + avec3d[0].yCoord, (double)f7 + avec3d[0].zCoord).tex((double)f1, (double)f3).color(this.particleRed, this.particleGreen, this.particleBlue, this.particleAlpha).lightmap(j, k).endVertex();
-        worldRendererIn.pos((double)f5 + avec3d[1].xCoord, (double)f6 + avec3d[1].yCoord, (double)f7 + avec3d[1].zCoord).tex((double)f1, (double)f2).color(this.particleRed, this.particleGreen, this.particleBlue, this.particleAlpha).lightmap(j, k).endVertex();
-        worldRendererIn.pos((double)f5 + avec3d[2].xCoord, (double)f6 + avec3d[2].yCoord, (double)f7 + avec3d[2].zCoord).tex((double)f, (double)f2).color(this.particleRed, this.particleGreen, this.particleBlue, this.particleAlpha).lightmap(j, k).endVertex();
-        worldRendererIn.pos((double)f5 + avec3d[3].xCoord, (double)f6 + avec3d[3].yCoord, (double)f7 + avec3d[3].zCoord).tex((double)f, (double)f3).color(this.particleRed, this.particleGreen, this.particleBlue, this.particleAlpha).lightmap(j, k).endVertex();
+        worldRendererIn.pos((double)f5 + avec3d[0].x, (double)f6 + avec3d[0].y, (double)f7 + avec3d[0].z).tex((double)f1, (double)f3).color(this.particleRed, this.particleGreen, this.particleBlue, this.particleAlpha).lightmap(j, k).endVertex();
+        worldRendererIn.pos((double)f5 + avec3d[1].x, (double)f6 + avec3d[1].y, (double)f7 + avec3d[1].z).tex((double)f1, (double)f2).color(this.particleRed, this.particleGreen, this.particleBlue, this.particleAlpha).lightmap(j, k).endVertex();
+        worldRendererIn.pos((double)f5 + avec3d[2].x, (double)f6 + avec3d[2].y, (double)f7 + avec3d[2].z).tex((double)f, (double)f2).color(this.particleRed, this.particleGreen, this.particleBlue, this.particleAlpha).lightmap(j, k).endVertex();
+        worldRendererIn.pos((double)f5 + avec3d[3].x, (double)f6 + avec3d[3].y, (double)f7 + avec3d[3].z).tex((double)f, (double)f3).color(this.particleRed, this.particleGreen, this.particleBlue, this.particleAlpha).lightmap(j, k).endVertex();
 	
         //GlStateManager.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
 	}

--- a/src/main/java/zmaster587/advancedRocketry/event/PlanetEventHandler.java
+++ b/src/main/java/zmaster587/advancedRocketry/event/PlanetEventHandler.java
@@ -60,6 +60,7 @@ import zmaster587.advancedRocketry.network.PacketSpaceStationInfo;
 import zmaster587.advancedRocketry.network.PacketStellarInfo;
 import zmaster587.advancedRocketry.stations.SpaceObjectManager;
 import zmaster587.advancedRocketry.util.BiomeHandler;
+import zmaster587.advancedRocketry.util.GravityHandler;
 import zmaster587.advancedRocketry.util.TransitionEntity;
 import zmaster587.advancedRocketry.world.ChunkManagerPlanet;
 import zmaster587.advancedRocketry.world.provider.WorldProviderPlanet;
@@ -153,6 +154,8 @@ public class PlanetEventHandler {
 //				((EntityPlayer)event.getEntity()).addStat(ARAchivements.weReallyWentToTheMoon);//TODO advancment trigger
 			}	
 		}
+		
+		GravityHandler.applyGravity(event.getEntity());
 	}
 
 	@SubscribeEvent

--- a/src/main/java/zmaster587/advancedRocketry/event/PlanetEventHandler.java
+++ b/src/main/java/zmaster587/advancedRocketry/event/PlanetEventHandler.java
@@ -1,9 +1,7 @@
 package zmaster587.advancedRocketry.event;
 
-import java.lang.ref.WeakReference;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -16,10 +14,9 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ActiveRenderInfo;
-import net.minecraft.entity.EntityTracker;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.EntityPlayer.SleepResult;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.EntityEquipmentSlot;
@@ -33,11 +30,8 @@ import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.client.event.EntityViewRenderEvent.FogColors;
 import net.minecraftforge.client.event.EntityViewRenderEvent.RenderFogEvent;
-import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
-import net.minecraftforge.event.entity.player.PlayerContainerEvent;
-import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickBlock;
 import net.minecraftforge.event.entity.player.PlayerSleepInBedEvent;
@@ -53,7 +47,6 @@ import net.minecraftforge.fml.common.network.FMLNetworkEvent.ClientDisconnection
 import net.minecraftforge.fml.common.network.FMLNetworkEvent.ServerConnectionFromClientEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import zmaster587.advancedRocketry.achievements.ARAchivements;
 import zmaster587.advancedRocketry.api.AdvancedRocketryBlocks;
 import zmaster587.advancedRocketry.api.AdvancedRocketryItems;
 import zmaster587.advancedRocketry.api.IPlanetaryProvider;
@@ -67,15 +60,12 @@ import zmaster587.advancedRocketry.network.PacketSpaceStationInfo;
 import zmaster587.advancedRocketry.network.PacketStellarInfo;
 import zmaster587.advancedRocketry.stations.SpaceObjectManager;
 import zmaster587.advancedRocketry.util.BiomeHandler;
-import zmaster587.advancedRocketry.util.RocketInventoryHelper;
 import zmaster587.advancedRocketry.util.TransitionEntity;
 import zmaster587.advancedRocketry.world.ChunkManagerPlanet;
 import zmaster587.advancedRocketry.world.provider.WorldProviderPlanet;
 import zmaster587.advancedRocketry.world.util.TeleporterNoPortal;
 import zmaster587.libVulpes.LibVulpes;
 import zmaster587.libVulpes.api.IModularArmor;
-import zmaster587.libVulpes.api.LibVulpesItems;
-import zmaster587.libVulpes.api.material.AllowedProducts;
 import zmaster587.libVulpes.network.PacketHandler;
 
 public class PlanetEventHandler {
@@ -91,23 +81,23 @@ public class PlanetEventHandler {
 	@SubscribeEvent
 	public void onCrafting(net.minecraftforge.fml.common.gameevent.PlayerEvent.ItemCraftedEvent event) {
 		if(event.crafting != null) {
-			Item item = event.crafting.getItem();
-			if(item == LibVulpesItems.itemHoloProjector) 
-				event.player.addStat(ARAchivements.holographic);
-			else if(item == Item.getItemFromBlock(AdvancedRocketryBlocks.blockRollingMachine))
-				event.player.addStat(ARAchivements.rollin);
-			else if(item == Item.getItemFromBlock(AdvancedRocketryBlocks.blockCrystallizer))
-				event.player.addStat(ARAchivements.crystalline);
-			else if(item == Item.getItemFromBlock(AdvancedRocketryBlocks.blockLathe))
-				event.player.addStat(ARAchivements.spinDoctor);
-			else if(item ==Item.getItemFromBlock(AdvancedRocketryBlocks.blockElectrolyser))
-				event.player.addStat(ARAchivements.electrifying);
-			else if(item == Item.getItemFromBlock(AdvancedRocketryBlocks.blockArcFurnace))
-				event.player.addStat(ARAchivements.feelTheHeat);
-			else if(item == Item.getItemFromBlock(AdvancedRocketryBlocks.blockWarpCore))
-				event.player.addStat(ARAchivements.warp);
-			else if(item == Item.getItemFromBlock(AdvancedRocketryBlocks.blockPlatePress))
-				event.player.addStat(ARAchivements.blockPresser);
+			Item item = event.crafting.getItem();//TODO Advancments for crafting.
+//			if(item == LibVulpesItems.itemHoloProjector) 
+//				event.player.addStat(ARAchivements.holographic);
+//			else if(item == Item.getItemFromBlock(AdvancedRocketryBlocks.blockRollingMachine))
+//				event.player.addStat(ARAchivements.rollin);
+//			else if(item == Item.getItemFromBlock(AdvancedRocketryBlocks.blockCrystallizer))
+//				event.player.addStat(ARAchivements.crystalline);
+//			else if(item == Item.getItemFromBlock(AdvancedRocketryBlocks.blockLathe))
+//				event.player.addStat(ARAchivements.spinDoctor);
+//			else if(item ==Item.getItemFromBlock(AdvancedRocketryBlocks.blockElectrolyser))
+//				event.player.addStat(ARAchivements.electrifying);
+//			else if(item == Item.getItemFromBlock(AdvancedRocketryBlocks.blockArcFurnace))
+//				event.player.addStat(ARAchivements.feelTheHeat);
+//			else if(item == Item.getItemFromBlock(AdvancedRocketryBlocks.blockWarpCore))
+//				event.player.addStat(ARAchivements.warp);
+//			else if(item == Item.getItemFromBlock(AdvancedRocketryBlocks.blockPlatePress))
+//				event.player.addStat(ARAchivements.blockPresser);
 		}
 	}
 	@SubscribeEvent
@@ -136,12 +126,12 @@ public class PlanetEventHandler {
 
 	@SubscribeEvent
 	public void onPickup(net.minecraftforge.fml.common.gameevent.PlayerEvent.ItemPickupEvent event) {
-		if(event.pickedUp != null && !event.pickedUp.getEntityItem().isEmpty()) {
+		if(event.pickedUp != null && !event.pickedUp.getItem().isEmpty()) {
 
-
-			zmaster587.libVulpes.api.material.Material mat = LibVulpes.materialRegistry.getMaterialFromItemStack( event.pickedUp.getEntityItem());
-			if(mat != null && mat.getUnlocalizedName().contains("Dilithium"))
-				event.player.addStat(ARAchivements.dilithiumCrystals);
+//TODO pickup advancment
+//			zmaster587.libVulpes.api.material.Material mat = LibVulpes.materialRegistry.getMaterialFromItemStack( event.pickedUp.getEntityItem());
+//			if(mat != null && mat.getUnlocalizedName().contains("Dilithium"))
+//				event.player.addStat(ARAchivements.dilithiumCrystals);
 		}
 	}
 
@@ -160,7 +150,7 @@ public class PlanetEventHandler {
 		if(!event.getEntity().world.isRemote && event.getEntity().world.getTotalWorldTime() % 20 ==0 && event.getEntity() instanceof EntityPlayer) {
 			if(DimensionManager.getInstance().getDimensionProperties(event.getEntity().world.provider.getDimension()).getName().equals("Luna") && 
 					event.getEntity().getPosition().distanceSq(67, 80, 2347) < 512 ) {
-				((EntityPlayer)event.getEntity()).addStat(ARAchivements.weReallyWentToTheMoon);
+//				((EntityPlayer)event.getEntity()).addStat(ARAchivements.weReallyWentToTheMoon);//TODO advancment trigger
 			}	
 		}
 	}
@@ -199,7 +189,7 @@ public class PlanetEventHandler {
 		}
 
 		if(!event.getWorld().isRemote && event.getItemStack() != null && event.getItemStack().getItem() == Item.getItemFromBlock(AdvancedRocketryBlocks.blockGenericSeat) && event.getWorld().getBlockState(event.getPos()).getBlock() == Blocks.TNT) {
-			event.getEntityPlayer().addStat(ARAchivements.beerOnTheSun);
+//			event.getEntityPlayer().addStat(ARAchivements.beerOnTheSun);
 		}
 	}
 
@@ -236,7 +226,7 @@ public class PlanetEventHandler {
 					TransitionEntity ent = entry.getValue();
 					if(ent.entity.world.getTotalWorldTime() >= entry.getKey()) {
 						ent.entity.setLocationAndAngles(ent.location.getX(), ent.location.getY(), ent.location.getZ(), ent.entity.rotationYaw, ent.entity.rotationPitch);
-						ent.entity.getServer().getPlayerList().transferPlayerToDimension((EntityPlayerMP)ent.entity, ent.dimId, new TeleporterNoPortal(ent.entity.getServer().worldServerForDimension(ent.dimId)));
+						ent.entity.getServer().getPlayerList().transferPlayerToDimension((EntityPlayerMP)ent.entity, ent.dimId, new TeleporterNoPortal(ent.entity.getServer().getWorld(ent.dimId)));
 						ent.entity.startRiding(ent.entity2);
 
 						itr.remove();
@@ -355,9 +345,9 @@ public class PlanetEventHandler {
 
 			if(event.getEntity().world.provider instanceof IPlanetaryProvider) {
 				Vec3d color = event.getEntity().world.provider.getSkyColor(event.getEntity(), 0f);
-				event.setRed((float) Math.min(color.xCoord*1.4f,1f));
-				event.setGreen((float) Math.min(color.yCoord*1.4f, 1f));
-				event.setBlue((float) Math.min(color.zCoord*1.4f, 1f));
+				event.setRed((float) Math.min(color.x*1.4f,1f));
+				event.setGreen((float) Math.min(color.y*1.4f, 1f));
+				event.setBlue((float) Math.min(color.z*1.4f, 1f));
 			}
 
 			if(endTime > 0) {

--- a/src/main/java/zmaster587/advancedRocketry/event/RocketEventHandler.java
+++ b/src/main/java/zmaster587/advancedRocketry/event/RocketEventHandler.java
@@ -13,7 +13,7 @@ import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.Entity;
 import net.minecraft.init.Blocks;
@@ -183,7 +183,7 @@ public class RocketEventHandler extends Gui {
 								//Get the first non-air block
 								for(yPosition = heightValue; yPosition > 0; yPosition-- ) {
 									block = worldObj.getBlockState(new BlockPos(xPosition, yPosition, zPosition));
-									if((color = block.getMapColor()) != MapColor.AIR) {
+									if((color = block.getMapColor(worldObj, thisPos)) != MapColor.AIR) {
 										break;
 									}
 								}
@@ -287,7 +287,7 @@ public class RocketEventHandler extends Gui {
 		double size = (getImgSize*5/(72-Minecraft.getMinecraft().getRenderViewEntity().posY - deltaY));
 
 
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 
 		//Less detailed land
 
@@ -319,7 +319,7 @@ public class RocketEventHandler extends Gui {
 		GL11.glBindTexture(GL11.GL_TEXTURE_2D,0);
 
 		buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_NORMAL);
-		GlStateManager.color((float)skyColor.xCoord, (float)skyColor.yCoord, (float)skyColor.zCoord, 0.05f);
+		GlStateManager.color((float)skyColor.x, (float)skyColor.y, (float)skyColor.z, 0.05f);
 
 		size = (getImgSize*100/(180-Minecraft.getMinecraft().getRenderViewEntity().posY - deltaY));
 
@@ -518,7 +518,7 @@ public class RocketEventHandler extends Gui {
 	private void renderModuleSlots(ItemStack armorStack, int slot, RenderGameOverlayEvent event) {
 		int index = 1;
 		float color = 0.85f + 0.15F*MathHelper.sin( 2f*(float)Math.PI*((Minecraft.getMinecraft().world.getTotalWorldTime()) % 60)/60f );
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 		GlStateManager.enableBlend();
 		GlStateManager.enableAlpha();
 		GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);

--- a/src/main/java/zmaster587/advancedRocketry/integration/jei/blastFurnace/BlastFurnaceCategory.java
+++ b/src/main/java/zmaster587/advancedRocketry/integration/jei/blastFurnace/BlastFurnaceCategory.java
@@ -22,4 +22,10 @@ public class BlastFurnaceCategory extends MachineCategoryTemplate<BlastFurnaceWr
 		return LibVulpes.proxy.getLocalizedString("tile.electricArcFurnace.name");
 	}
 
+    @Override
+    public String getModName()
+    {
+        return "Advanced Rocketry";
+    }
+
 }

--- a/src/main/java/zmaster587/advancedRocketry/integration/jei/chemicalReactor/ChemicalReactorCategory.java
+++ b/src/main/java/zmaster587/advancedRocketry/integration/jei/chemicalReactor/ChemicalReactorCategory.java
@@ -22,4 +22,10 @@ public class ChemicalReactorCategory extends MachineCategoryTemplate<ChemicalRea
 		return LibVulpes.proxy.getLocalizedString("tile.chemreactor.name");
 	}
 
+    @Override
+    public String getModName()
+    {
+        return "Advanced Rocketry";
+    }
+
 }

--- a/src/main/java/zmaster587/advancedRocketry/integration/jei/crystallizer/CrystallizerCategory.java
+++ b/src/main/java/zmaster587/advancedRocketry/integration/jei/crystallizer/CrystallizerCategory.java
@@ -22,4 +22,10 @@ public class CrystallizerCategory extends MachineCategoryTemplate<CrystallizerWr
 		return LibVulpes.proxy.getLocalizedString("tile.Crystallizer.name");
 	}
 
+    @Override
+    public String getModName()
+    {
+        return "Advanced Rocketry";
+    }
+
 }

--- a/src/main/java/zmaster587/advancedRocketry/integration/jei/electrolyser/ElectrolyzerCategory.java
+++ b/src/main/java/zmaster587/advancedRocketry/integration/jei/electrolyser/ElectrolyzerCategory.java
@@ -22,4 +22,10 @@ public class ElectrolyzerCategory extends MachineCategoryTemplate<ElectrolyzerWr
 		return LibVulpes.proxy.getLocalizedString("tile.electrolyser.name");
 	}
 
+    @Override
+    public String getModName()
+    {
+        return "Advanced Rocketry";
+    }
+
 }

--- a/src/main/java/zmaster587/advancedRocketry/integration/jei/lathe/LatheCategory.java
+++ b/src/main/java/zmaster587/advancedRocketry/integration/jei/lathe/LatheCategory.java
@@ -22,4 +22,10 @@ public class LatheCategory extends MachineCategoryTemplate<LatheWrapper> {
 		return LibVulpes.proxy.getLocalizedString("tile.lathe.name");
 	}
 
+    @Override
+    public String getModName()
+    {
+        return "Advanced Rocketry";
+    }
+
 }

--- a/src/main/java/zmaster587/advancedRocketry/integration/jei/platePresser/PlatePressCategory.java
+++ b/src/main/java/zmaster587/advancedRocketry/integration/jei/platePresser/PlatePressCategory.java
@@ -22,4 +22,10 @@ public class PlatePressCategory extends MachineCategoryTemplate<PlatePressWrappe
 		return LibVulpes.proxy.getLocalizedString("tile.blockHandPress.name");
 	}
 
+    @Override
+    public String getModName()
+    {
+        return "Advanced Rocketry";
+    }
+
 }

--- a/src/main/java/zmaster587/advancedRocketry/integration/jei/precisionAssembler/PrecisionAssemblerCategory.java
+++ b/src/main/java/zmaster587/advancedRocketry/integration/jei/precisionAssembler/PrecisionAssemblerCategory.java
@@ -24,4 +24,10 @@ public class PrecisionAssemblerCategory extends MachineCategoryTemplate<Precisio
 		return LibVulpes.proxy.getLocalizedString("tile.precisionAssemblingMachine.name");
 	}
 
+    @Override
+    public String getModName()
+    {
+        return "Advanced Rocketry";
+    }
+
 }

--- a/src/main/java/zmaster587/advancedRocketry/integration/jei/rollingMachine/RollingMachineCategory.java
+++ b/src/main/java/zmaster587/advancedRocketry/integration/jei/rollingMachine/RollingMachineCategory.java
@@ -22,4 +22,10 @@ public class RollingMachineCategory extends MachineCategoryTemplate<RollingMachi
 		return LibVulpes.proxy.getLocalizedString("tile.rollingMachine.name");
 	}
 
+    @Override
+    public String getModName()
+    {
+        return "Advanced Rocketry";
+    }
+
 }

--- a/src/main/java/zmaster587/advancedRocketry/integration/jei/sawmill/SawMillCategory.java
+++ b/src/main/java/zmaster587/advancedRocketry/integration/jei/sawmill/SawMillCategory.java
@@ -22,4 +22,10 @@ public class SawMillCategory extends MachineCategoryTemplate<SawMillWrapper> {
 		return LibVulpes.proxy.getLocalizedString("tile.cuttingMachine.name");
 	}
 
+    @Override
+    public String getModName()
+    {
+        return "Advanced Rocketry";
+    }
+
 }

--- a/src/main/java/zmaster587/advancedRocketry/inventory/ContainerSpaceLaser.java
+++ b/src/main/java/zmaster587/advancedRocketry/inventory/ContainerSpaceLaser.java
@@ -54,7 +54,7 @@ public class ContainerSpaceLaser extends Container {
 			prevEnergy = laserTile.getBatteries().getEnergyStored() ;
 			for (int j = 0; j < this.listeners.size(); ++j)
 			{
-				((IContainerListener)this.listeners.get(j)).sendProgressBarUpdate(this, 0, prevEnergy/100);
+				((IContainerListener)this.listeners.get(j)).sendWindowProperty(this, 0, prevEnergy/100);
 			}
 		}
 
@@ -63,11 +63,11 @@ public class ContainerSpaceLaser extends Container {
 
 
 			for(int i = 0; i < this.listeners.size(); i++) {
-				((IContainerListener)this.listeners.get(i)).sendProgressBarUpdate(this, 1, prevLaserX & 65535);
+				((IContainerListener)this.listeners.get(i)).sendWindowProperty(this, 1, prevLaserX & 65535);
 
 				int j = prevLaserX >>> 16;
 			//if(j != 0)
-			((IContainerListener)this.listeners.get(i)).sendProgressBarUpdate(this, 2, j);
+			((IContainerListener)this.listeners.get(i)).sendWindowProperty(this, 2, j);
 			}
 		}
 
@@ -75,28 +75,28 @@ public class ContainerSpaceLaser extends Container {
 			prevLaserZ = laserTile.laserZ;
 
 			for(int i = 0; i < this.listeners.size(); i++) {
-				((IContainerListener)this.listeners.get(i)).sendProgressBarUpdate(this, 3, prevLaserZ & 65535);
+				((IContainerListener)this.listeners.get(i)).sendWindowProperty(this, 3, prevLaserZ & 65535);
 
 				int j = prevLaserZ >>> 16;
 			//if(j != 0)
-			((IContainerListener)this.listeners.get(i)).sendProgressBarUpdate(this, 4, j);
+			((IContainerListener)this.listeners.get(i)).sendWindowProperty(this, 4, j);
 			}
 		}
 		if(currMode.compareTo(laserTile.getMode()) != 0) {
 			for(int i = 0; i < this.listeners.size(); i++) {
-				((IContainerListener)this.listeners.get(i)).sendProgressBarUpdate(this, 5, laserTile.getMode().ordinal());
+				((IContainerListener)this.listeners.get(i)).sendWindowProperty(this, 5, laserTile.getMode().ordinal());
 			}
 		}
 		if(jammed != laserTile.isJammed()) {
 			jammed = laserTile.isJammed();
 			for(int i = 0; i < this.listeners.size(); i++) {
-				((IContainerListener)this.listeners.get(i)).sendProgressBarUpdate(this, 6, laserTile.isJammed() ? 1 : 0);
+				((IContainerListener)this.listeners.get(i)).sendWindowProperty(this, 6, laserTile.isJammed() ? 1 : 0);
 			}
 		}
 		if(finished != laserTile.isFinished()) {
 			finished = laserTile.isFinished();
 			for(int i = 0; i < this.listeners.size(); i++) {
-				((IContainerListener)this.listeners.get(i)).sendProgressBarUpdate(this, 7, laserTile.isFinished() ? 1 : 0);
+				((IContainerListener)this.listeners.get(i)).sendWindowProperty(this, 7, laserTile.isFinished() ? 1 : 0);
 			}
 		}
 	}

--- a/src/main/java/zmaster587/advancedRocketry/inventory/GuiOreMappingSatellite.java
+++ b/src/main/java/zmaster587/advancedRocketry/inventory/GuiOreMappingSatellite.java
@@ -13,7 +13,7 @@ import zmaster587.libVulpes.util.VulpineMath;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.texture.TextureUtil;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.player.EntityPlayer;
@@ -240,7 +240,7 @@ public class GuiOreMappingSatellite extends GuiContainer {
 	@Override
 	protected void drawGuiContainerForegroundLayer(int p_146979_1_,	int p_146979_2_) {
 
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 		//Draw fancy things
 		GlStateManager.disableTexture2D();
 		GlStateManager.color(0f, 0.8f, 0f);
@@ -315,7 +315,7 @@ public class GuiOreMappingSatellite extends GuiContainer {
 			merged = false;
 		}
 
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 		//Render the background then render
 		GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 		this.mc.renderEngine.bindTexture(backdrop);
@@ -366,4 +366,14 @@ public class GuiOreMappingSatellite extends GuiContainer {
 		//this.drawString(this.fontRendererObj, "Value: ", 6 + x, 65 + y, 0xF0F0F0);
 		//this.drawString(this.fontRendererObj, String.valueOf(mouseValue), 6 + x, 79 + y, 0xF0F0F0);
 	}
+
+    /**
+     * Draws the screen and all the components in it.
+     */
+    public void drawScreen(int mouseX, int mouseY, float partialTicks)
+    {
+        this.drawDefaultBackground();
+        super.drawScreen(mouseX, mouseY, partialTicks);
+        this.renderHoveredToolTip(mouseX, mouseY);
+    }
 }

--- a/src/main/java/zmaster587/advancedRocketry/inventory/GuiPlanetButton.java
+++ b/src/main/java/zmaster587/advancedRocketry/inventory/GuiPlanetButton.java
@@ -3,7 +3,7 @@ package zmaster587.advancedRocketry.inventory;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 
 import org.lwjgl.opengl.GL11;
@@ -23,12 +23,12 @@ public class GuiPlanetButton extends GuiImageButton {
 	}
 
 	@Override
-	public void drawButton(Minecraft minecraft, int par2, int par3)
+	public void drawButton(Minecraft minecraft, int par2, int par3, float f)
 	{
 		if (this.visible)
 		{
 			//
-			this.hovered = par2 >= this.xPosition && par3 >= this.yPosition && par2 < this.xPosition + this.width && par3 < this.yPosition + this.height;
+			this.hovered = par2 >= this.x && par3 >= this.y && par2 < this.x + this.width && par3 < this.y + this.height;
 			int hoverState = this.getHoverState(this.hovered);
 
 			/*if(mousePressed(minecraft, par2, par3) && buttonTexture[2] != null)
@@ -48,13 +48,13 @@ public class GuiPlanetButton extends GuiImageButton {
            
 	
 	        Tessellator tessellator = Tessellator.getInstance();
-	        VertexBuffer vertexbuffer = tessellator.getBuffer();
+	        BufferBuilder vertexbuffer = tessellator.getBuffer();
 	        GL11.glPushMatrix();
 	        GL11.glRotated(90, -1, 0, 0);
 	        //GL11.glTranslatef(xPosition, 100 + this.zLevel, yPosition);
 	        float newWidth = width/2f;
 	        
-	        RenderPlanetarySky.renderPlanetPubHelper(vertexbuffer, properties.getPlanetIcon(), (int)(xPosition + newWidth), (int)(yPosition + newWidth), (double)this.zLevel, newWidth, 1f, properties.getSolarTheta(), properties.hasAtmosphere(), properties.skyColor, properties.ringColor, properties.isGasGiant(), properties.hasRings());
+	        RenderPlanetarySky.renderPlanetPubHelper(vertexbuffer, properties.getPlanetIcon(), (int)(x + newWidth), (int)(y + newWidth), (double)this.zLevel, newWidth, 1f, properties.getSolarTheta(), properties.hasAtmosphere(), properties.skyColor, properties.ringColor, properties.isGasGiant(), properties.hasRings());
             GL11.glPopMatrix();
 	        
 	        /*vertexbuffer.begin(7, DefaultVertexFormats.POSITION_TEX);

--- a/src/main/java/zmaster587/advancedRocketry/inventory/GuiProgressBarContainer.java
+++ b/src/main/java/zmaster587/advancedRocketry/inventory/GuiProgressBarContainer.java
@@ -5,7 +5,7 @@ import org.lwjgl.opengl.GL11;
 import zmaster587.libVulpes.render.RenderHelper;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.inventory.Container;
 import net.minecraft.util.EnumFacing;
@@ -48,11 +48,21 @@ public abstract class GuiProgressBarContainer extends GuiContainer {
      */
     public void drawTexturedModalRectWithCustomSize(int x, int y, int u, int v, int width, int height)
     {
-    	VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+    	BufferBuilder buffer = Tessellator.getInstance().getBuffer();
         float f = 0.00390625F;
         float f1 = 0.00390625F;
         buffer.begin(GL11.GL_QUADS, buffer.getVertexFormat());
         RenderHelper.renderNorthFaceWithUV(buffer, this.zLevel, x, y, x + width, y + height, (u + 0) * f, (u + width) * f, (v + 0) * f1, (v + height) * f1);
         buffer.finishDrawing();
+    }
+
+    /**
+     * Draws the screen and all the components in it.
+     */
+    public void drawScreen(int mouseX, int mouseY, float partialTicks)
+    {
+        this.drawDefaultBackground();
+        super.drawScreen(mouseX, mouseY, partialTicks);
+        this.renderHoveredToolTip(mouseX, mouseY);
     }
 }

--- a/src/main/java/zmaster587/advancedRocketry/inventory/modules/ModuleData.java
+++ b/src/main/java/zmaster587/advancedRocketry/inventory/modules/ModuleData.java
@@ -100,9 +100,9 @@ public class ModuleData extends ModuleBase implements IButtonInventory {
 	public void sendChanges(Container container, IContainerListener crafter,
 			int variableId, int localId) {
 		if(localId < data.length)
-			crafter.sendProgressBarUpdate(container, variableId, data[localId].getData());
+			crafter.sendWindowProperty(container, variableId, data[localId].getData());
 		else
-			crafter.sendProgressBarUpdate(container, variableId, data[0].getDataType().ordinal());
+			crafter.sendWindowProperty(container, variableId, data[0].getDataType().ordinal());
 	}
 
 	@Override

--- a/src/main/java/zmaster587/advancedRocketry/inventory/modules/ModuleOreMapper.java
+++ b/src/main/java/zmaster587/advancedRocketry/inventory/modules/ModuleOreMapper.java
@@ -9,7 +9,7 @@ import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
@@ -117,7 +117,7 @@ public class ModuleOreMapper extends ModuleBase {
 		super.renderForeground(guiOffsetX, guiOffsetY, mouseX, mouseY, zLevel, gui,
 				font);
 		
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 		
 		//Draw fancy things
 		GlStateManager.disableTexture2D();
@@ -203,7 +203,7 @@ public class ModuleOreMapper extends ModuleBase {
 		//Draw the actual display
 		int zLevel = 100;
 		GL11.glBindTexture(GL11.GL_TEXTURE_2D, texture.getTextureId());
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 		buffer.begin(GL11.GL_QUADS, buffer.getVertexFormat());
 		RenderHelper.renderNorthFaceWithUV(buffer, zLevel, 47 + x,  20 + y, 47 + x + SCREEN_SIZE,  20 + y + SCREEN_SIZE, 0, 1, 0, 1);
 		buffer.finishDrawing();

--- a/src/main/java/zmaster587/advancedRocketry/inventory/modules/ModulePanetImage.java
+++ b/src/main/java/zmaster587/advancedRocketry/inventory/modules/ModulePanetImage.java
@@ -8,7 +8,7 @@ import org.lwjgl.opengl.GL11;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import zmaster587.advancedRocketry.client.render.planet.RenderPlanetarySky;
 import zmaster587.advancedRocketry.dimension.DimensionProperties;
 import zmaster587.libVulpes.inventory.modules.ModuleBase;
@@ -30,7 +30,7 @@ public class ModulePanetImage extends ModuleBase {
 		super.renderBackground(gui, x, y, mouseX, mouseY, font);
 
 		Tessellator tessellator = Tessellator.getInstance();
-		VertexBuffer vertexbuffer = tessellator.getBuffer();
+		BufferBuilder vertexbuffer = tessellator.getBuffer();
 		GL11.glPushMatrix();
 		GL11.glRotated(90, -1, 0, 0);
 		//GL11.glTranslatef(xPosition, 100 + this.zLevel, yPosition);

--- a/src/main/java/zmaster587/advancedRocketry/inventory/modules/ModulePlanetSelector.java
+++ b/src/main/java/zmaster587/advancedRocketry/inventory/modules/ModulePlanetSelector.java
@@ -37,7 +37,7 @@ import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IContainerListener;
@@ -338,7 +338,7 @@ public class ModulePlanetSelector extends ModuleContainerPan implements IButtonI
 		this.screenSizeY = Minecraft.getMinecraft().displayHeight;
 		for(ModuleBase module : this.planetList) {
 			for(GuiButton module2 : module.addButtons(currentPosX, currentPosY)) {
-				if(module2.xPosition > 128 + offsetX || clickablePlanetList == null || !clickablePlanetList.isEnabled())
+				if(module2.x > 128 + offsetX || clickablePlanetList == null || !clickablePlanetList.isEnabled())
 					buttonList.add( module2 );
 			}
 		}
@@ -401,7 +401,7 @@ public class ModulePlanetSelector extends ModuleContainerPan implements IButtonI
 		float cos = (float) Math.cos(theta);
 		float sin = (float) Math.sin(theta);
 
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 		GL11.glPushMatrix();
 
 		//Render orbits

--- a/src/main/java/zmaster587/advancedRocketry/item/ItemAsteroidChip.java
+++ b/src/main/java/zmaster587/advancedRocketry/item/ItemAsteroidChip.java
@@ -1,8 +1,11 @@
 package zmaster587.advancedRocketry.item;
 
+import com.mojang.realmsclient.gui.ChatFormatting;
+
+import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import com.mojang.realmsclient.gui.ChatFormatting;
+import net.minecraft.world.World;
 
 public class ItemAsteroidChip  extends ItemMultiData {
 
@@ -60,7 +63,7 @@ public class ItemAsteroidChip  extends ItemMultiData {
 	}
 
 	@Override
-	public void addInformation(ItemStack stack, net.minecraft.entity.player.EntityPlayer player, java.util.List list, boolean bool) {
+	public void addInformation(ItemStack stack, World player, java.util.List list, ITooltipFlag bool) {
 
 		if(!stack.hasTagCompound()) {
 			list.add("Unprogrammed");

--- a/src/main/java/zmaster587/advancedRocketry/item/ItemAtmosphereAnalzer.java
+++ b/src/main/java/zmaster587/advancedRocketry/item/ItemAtmosphereAnalzer.java
@@ -18,7 +18,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.EntityLivingBase;
@@ -113,7 +113,7 @@ public class ItemAtmosphereAnalzer extends Item implements IArmorComponent {
 		GL11.glTranslatef(screenX + 12, screenY + 8, 0);
 		GL11.glRotatef(( System.currentTimeMillis() / 100 ) % 360, 0, 0, 1);
 		
-		VertexBuffer buffer = Tessellator.getInstance().getBuffer();
+		BufferBuilder buffer = Tessellator.getInstance().getBuffer();
 		
 		buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);
 		RenderHelper.renderNorthFaceWithUV(buffer, -1, -16,  -16, 16,  16, 0, 1, 0, 1);

--- a/src/main/java/zmaster587/advancedRocketry/item/ItemBeaconFinder.java
+++ b/src/main/java/zmaster587/advancedRocketry/item/ItemBeaconFinder.java
@@ -14,7 +14,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -84,7 +84,7 @@ public class ItemBeaconFinder extends Item implements IArmorComponent {
 				GlStateManager.color(0.5f, 0.5f, 1, 1);
 				
 		        Tessellator tessellator = Tessellator.getInstance();
-		        VertexBuffer vertexbuffer = tessellator.getBuffer();
+		        BufferBuilder vertexbuffer = tessellator.getBuffer();
 		        
 		        vertexbuffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);
 		        RenderHelper.renderNorthFaceWithUV(vertexbuffer, -1000, -10, 0, 10, 20, 0, 1, 0, 1);

--- a/src/main/java/zmaster587/advancedRocketry/item/ItemBiomeChanger.java
+++ b/src/main/java/zmaster587/advancedRocketry/item/ItemBiomeChanger.java
@@ -1,11 +1,11 @@
 package zmaster587.advancedRocketry.item;
 
-import io.netty.buffer.ByteBuf;
-
 import java.util.LinkedList;
 import java.util.List;
 
+import io.netty.buffer.ByteBuf;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -64,8 +64,8 @@ public class ItemBiomeChanger extends ItemSatelliteIdentificationChip implements
 	}
 
 	@Override
-	public void addInformation(ItemStack stack, EntityPlayer player,
-			List list, boolean arg5) {
+	public void addInformation(ItemStack stack, World player,
+			List list, ITooltipFlag arg5) {
 
 		SatelliteBase sat = DimensionManager.getInstance().getSatellite(this.getSatelliteId(stack));
 
@@ -77,7 +77,7 @@ public class ItemBiomeChanger extends ItemSatelliteIdentificationChip implements
 			list.add("Unprogrammed");
 		else if(mapping == null)
 			list.add("Satellite not yet launched");
-		else if(mapping.getDimensionId() == player.world.provider.getDimension()) {
+		else if(mapping.getDimensionId() == player.provider.getDimension()) {
 			list.add("Connected");
 			list.add("Selected Biome: " + Biome.getBiome(mapping.getBiome()).getBiomeName());
 			list.add("Num Biomes Scanned: " + mapping.discoveredBiomes().size());

--- a/src/main/java/zmaster587/advancedRocketry/item/ItemBlockFluidTank.java
+++ b/src/main/java/zmaster587/advancedRocketry/item/ItemBlockFluidTank.java
@@ -2,26 +2,22 @@ package zmaster587.advancedRocketry.item;
 
 import java.util.List;
 
-import zmaster587.advancedRocketry.capability.TankCapabilityItemStack;
-import zmaster587.advancedRocketry.tile.TileFluidTank;
-import zmaster587.libVulpes.util.FluidUtils;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumFacing;
-import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
+import zmaster587.advancedRocketry.tile.TileFluidTank;
 
 public class ItemBlockFluidTank extends ItemBlock {
 
@@ -30,8 +26,8 @@ public class ItemBlockFluidTank extends ItemBlock {
 	}
 
 	@Override
-	public void addInformation(ItemStack stack, EntityPlayer player,
-			List list, boolean bool) {
+	public void addInformation(ItemStack stack, World player,
+			List list, ITooltipFlag bool) {
 		super.addInformation(stack, player, list, bool);
 
 		FluidStack fluidStack = getFluid(stack);

--- a/src/main/java/zmaster587/advancedRocketry/item/ItemData.java
+++ b/src/main/java/zmaster587/advancedRocketry/item/ItemData.java
@@ -2,16 +2,15 @@ package zmaster587.advancedRocketry.item;
 
 import java.util.List;
 
-import zmaster587.advancedRocketry.api.DataStorage;
-import zmaster587.libVulpes.items.ItemIngredient;
 import net.minecraft.client.resources.I18n;
-import net.minecraft.creativetab.CreativeTabs;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.Item;
+import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import zmaster587.advancedRocketry.api.DataStorage;
+import zmaster587.libVulpes.items.ItemIngredient;
 
 public class ItemData extends ItemIngredient {
 
@@ -89,8 +88,8 @@ public class ItemData extends ItemIngredient {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void addInformation(ItemStack stack, EntityPlayer player,
-			List list, boolean bool) {
+	public void addInformation(ItemStack stack, World player,
+			List list, ITooltipFlag bool) {
 		super.addInformation(stack, player, list, bool);
 
 		DataStorage data = getDataStorage(stack);

--- a/src/main/java/zmaster587/advancedRocketry/item/ItemIdWithName.java
+++ b/src/main/java/zmaster587/advancedRocketry/item/ItemIdWithName.java
@@ -4,10 +4,11 @@ import java.util.List;
 
 import com.mojang.realmsclient.gui.ChatFormatting;
 
-import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.World;
 
 public class ItemIdWithName extends Item {
 	
@@ -31,8 +32,8 @@ public class ItemIdWithName extends Item {
 	
 	
 	@Override
-	public void addInformation(ItemStack stack, EntityPlayer player,
-			List list, boolean bool) {
+	public void addInformation(ItemStack stack, World player,
+			List list, ITooltipFlag bool) {
 		if(stack.getItemDamage() == -1) {
 			list.add(ChatFormatting.GRAY + "Unprogrammed");
 		}

--- a/src/main/java/zmaster587/advancedRocketry/item/ItemMultiData.java
+++ b/src/main/java/zmaster587/advancedRocketry/item/ItemMultiData.java
@@ -3,11 +3,13 @@ package zmaster587.advancedRocketry.item;
 import java.util.List;
 
 import net.minecraft.client.resources.I18n;
+import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import zmaster587.advancedRocketry.api.DataStorage;
@@ -112,8 +114,8 @@ public class ItemMultiData extends Item {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void addInformation(ItemStack stack, EntityPlayer player,
-			List list, boolean bool) {
+	public void addInformation(ItemStack stack, World player,
+			List list, ITooltipFlag bool) {
 		super.addInformation(stack, player, list, bool);
 
 		MultiData data = getDataStorage(stack);

--- a/src/main/java/zmaster587/advancedRocketry/item/ItemOreScanner.java
+++ b/src/main/java/zmaster587/advancedRocketry/item/ItemOreScanner.java
@@ -3,6 +3,7 @@ package zmaster587.advancedRocketry.item;
 import java.util.LinkedList;
 import java.util.List;
 
+import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -26,8 +27,8 @@ public class ItemOreScanner extends Item implements IModularInventory {
 
 
 	@Override
-	public void addInformation(ItemStack stack, EntityPlayer player,
-			List list, boolean arg5) {
+	public void addInformation(ItemStack stack, World player,
+			List list, ITooltipFlag arg5) {
 		
 		SatelliteBase sat = DimensionManager.getInstance().getSatellite(this.getSatelliteID(stack));
 		
@@ -39,7 +40,7 @@ public class ItemOreScanner extends Item implements IModularInventory {
 			list.add("Unprogrammed");
 		else if(mapping == null)
 			list.add("Satellite not yet launched");
-		else if(mapping.getDimensionId() == player.world.provider.getDimension()) {
+		else if(mapping.getDimensionId() == player.provider.getDimension()) {
 			list.add("Connected");
 			list.add("Max Zoom: " + mapping.getZoomRadius());
 			list.add("Can filter ore: " + mapping.canFilterOre());

--- a/src/main/java/zmaster587/advancedRocketry/item/ItemPlanetIdentificationChip.java
+++ b/src/main/java/zmaster587/advancedRocketry/item/ItemPlanetIdentificationChip.java
@@ -1,12 +1,16 @@
 package zmaster587.advancedRocketry.item;
 
+import java.util.List;
+
 import com.mojang.realmsclient.gui.ChatFormatting;
 
 import zmaster587.advancedRocketry.dimension.DimensionManager;
 import zmaster587.advancedRocketry.dimension.DimensionProperties;
+import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.World;
 
 public class ItemPlanetIdentificationChip extends ItemIdWithName {
 
@@ -124,7 +128,8 @@ public class ItemPlanetIdentificationChip extends ItemIdWithName {
 	}
 
 	@Override
-	public void addInformation(ItemStack stack, net.minecraft.entity.player.EntityPlayer player, java.util.List list, boolean bool) {
+	public void addInformation(ItemStack stack, World player, List list,
+            ITooltipFlag bool){
 
 		if(!stack.hasTagCompound()) {
 			list.add("Unprogrammed");

--- a/src/main/java/zmaster587/advancedRocketry/item/ItemSatellite.java
+++ b/src/main/java/zmaster587/advancedRocketry/item/ItemSatellite.java
@@ -9,10 +9,12 @@ import zmaster587.advancedRocketry.api.satellite.SatelliteBase;
 import zmaster587.advancedRocketry.api.satellite.SatelliteProperties;
 import zmaster587.libVulpes.util.EmbeddedInventory;
 import zmaster587.libVulpes.util.ZUtils;
+import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.World;
 
 public class ItemSatellite extends ItemIdWithName {
 
@@ -114,8 +116,8 @@ public class ItemSatellite extends ItemIdWithName {
 
 
 	@Override
-	public void addInformation(ItemStack stack, EntityPlayer player,
-			List list, boolean bool) {
+	public void addInformation(ItemStack stack, World player, List list,
+            ITooltipFlag bool) {
 
 		SatelliteProperties properties = getSatellite(stack);
 

--- a/src/main/java/zmaster587/advancedRocketry/item/ItemSatelliteIdentificationChip.java
+++ b/src/main/java/zmaster587/advancedRocketry/item/ItemSatelliteIdentificationChip.java
@@ -2,6 +2,7 @@ package zmaster587.advancedRocketry.item;
 
 import java.util.List;
 
+import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -127,8 +128,8 @@ public class ItemSatelliteIdentificationChip extends Item implements ISatelliteI
 	}
 
 	@Override
-	public void addInformation(ItemStack stack, EntityPlayer player,
-			List list, boolean bool) {
+	public void addInformation(ItemStack stack, World player,
+			List list, ITooltipFlag bool) {
 		int worldId = getWorldId(stack);
 		long satId = getSatelliteId(stack);
 

--- a/src/main/java/zmaster587/advancedRocketry/item/ItemSpaceElevatorChip.java
+++ b/src/main/java/zmaster587/advancedRocketry/item/ItemSpaceElevatorChip.java
@@ -2,15 +2,13 @@ package zmaster587.advancedRocketry.item;
 
 import java.util.List;
 
-import zmaster587.advancedRocketry.util.DimensionBlockPosition;
-import zmaster587.advancedRocketry.util.NBTStorableListList;
-import zmaster587.libVulpes.util.HashedBlockPosition;
-import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
-import net.minecraftforge.common.util.Constants.NBT;
+import net.minecraft.world.World;
+import zmaster587.advancedRocketry.util.DimensionBlockPosition;
+import zmaster587.advancedRocketry.util.NBTStorableListList;
 
 public class ItemSpaceElevatorChip extends Item {
 
@@ -53,8 +51,8 @@ public class ItemSpaceElevatorChip extends Item {
 	}
 	
 	@Override
-	public void addInformation(ItemStack stack, EntityPlayer player,
-			List list, boolean bool) {
+	public void addInformation(ItemStack stack, World player,
+			List list, ITooltipFlag bool) {
 		
 		int numPos = getBlockPositions(stack).size();
 		

--- a/src/main/java/zmaster587/advancedRocketry/item/ItemStationChip.java
+++ b/src/main/java/zmaster587/advancedRocketry/item/ItemStationChip.java
@@ -4,13 +4,16 @@ import java.util.List;
 
 import com.mojang.realmsclient.gui.ChatFormatting;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.entity.Entity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.World;
 import zmaster587.advancedRocketry.api.Configuration;
 import zmaster587.advancedRocketry.api.stations.ISpaceObject;
 import zmaster587.advancedRocketry.stations.SpaceObjectManager;
 import zmaster587.libVulpes.util.Vector3F;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 
 /**
  * MetaData corresponds to the id
@@ -85,16 +88,16 @@ public class ItemStationChip extends ItemIdWithName {
 	}
 
 	@Override
-	public void addInformation(ItemStack stack, EntityPlayer player, List list,
-			boolean bool) {
+	public void addInformation(ItemStack stack, World player, List list,
+			ITooltipFlag bool) {
 		if(getUUID(stack) == 0)
 			list.add(ChatFormatting.GRAY + "Unprogrammed");
 		else {
 			list.add(ChatFormatting.GREEN + "Station " + getUUID(stack));
 			super.addInformation(stack, player, list, bool);
-			
-			if(player.world.provider.getDimension() == Configuration.spaceDimId) {
-				ISpaceObject obj = SpaceObjectManager.getSpaceManager().getSpaceStationFromBlockCoords(player.getPosition());
+			if(player.provider.getDimension() == Configuration.spaceDimId) {
+	            Entity p = Minecraft.getMinecraft().player;
+				ISpaceObject obj = SpaceObjectManager.getSpaceManager().getSpaceStationFromBlockCoords(p.getPosition());
 				
 				if(obj != null) {
 					Vector3F<Float> vec = getTakeoffCoords(stack, obj.getOrbitingPlanetId());

--- a/src/main/java/zmaster587/advancedRocketry/item/components/ItemPressureTank.java
+++ b/src/main/java/zmaster587/advancedRocketry/item/components/ItemPressureTank.java
@@ -3,6 +3,7 @@ package zmaster587.advancedRocketry.item.components;
 import java.util.List;
 
 import net.minecraft.client.gui.Gui;
+import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.EntityEquipmentSlot;
@@ -34,8 +35,8 @@ public class ItemPressureTank extends ItemIngredient implements IArmorComponent 
 	}
 	
 	@Override
-	public void addInformation(ItemStack stack, EntityPlayer player,
-			List list, boolean bool) {
+	public void addInformation(ItemStack stack, World player, List list,
+            ITooltipFlag bool) {
 		super.addInformation(stack, player, list, bool);
 		
 		FluidStack fluidStack = FluidUtils.getFluidForItem(stack);

--- a/src/main/java/zmaster587/advancedRocketry/item/tools/ItemBasicLaserGun.java
+++ b/src/main/java/zmaster587/advancedRocketry/item/tools/ItemBasicLaserGun.java
@@ -239,10 +239,10 @@ public class ItemBasicLaserGun extends Item {
 
 		Vec3d vec3d = new Vec3d(entity.posX, entity.posY + entity.getEyeHeight(), entity.posZ);
 		Vec3d vec3d1 = entity.getLook(0);
-		Vec3d vec3d2 = vec3d.addVector(vec3d1.xCoord * reachDistance, vec3d1.yCoord * reachDistance, vec3d1.zCoord * reachDistance);
+		Vec3d vec3d2 = vec3d.addVector(vec3d1.x * reachDistance, vec3d1.y * reachDistance, vec3d1.z * reachDistance);
 
 
-		List<Entity> list = world.getEntitiesInAABBexcluding(entity, entity.getEntityBoundingBox().addCoord(vec3d1.xCoord * reachDistance, vec3d1.yCoord * reachDistance, vec3d1.zCoord * reachDistance).expand(1.0D, 1.0D, 1.0D), Predicates.and(EntitySelectors.NOT_SPECTATING, new Predicate<Entity>()
+		List<Entity> list = world.getEntitiesInAABBexcluding(entity, entity.getEntityBoundingBox().expand(vec3d1.x * reachDistance, vec3d1.y * reachDistance, vec3d1.z * reachDistance).expand(1.0D, 1.0D, 1.0D), Predicates.and(EntitySelectors.NOT_SPECTATING, new Predicate<Entity>()
 				{
 			public boolean apply(@Nullable Entity p_apply_1_)
 			{
@@ -253,10 +253,10 @@ public class ItemBasicLaserGun extends Item {
 		for (int j = 0; j < list.size(); ++j)
 		{
 			Entity entity1 = (Entity)list.get(j);
-			AxisAlignedBB axisalignedbb = entity1.getEntityBoundingBox().expandXyz((double)entity1.getCollisionBorderSize());
+			AxisAlignedBB axisalignedbb = entity1.getEntityBoundingBox().grow((double)entity1.getCollisionBorderSize());
 			RayTraceResult raytraceresult = axisalignedbb.calculateIntercept(vec3d, vec3d2);
 
-			if (axisalignedbb.isVecInside(vec3d))
+			if (axisalignedbb.contains(vec3d))
 			{
 			}
 			else if (raytraceresult != null)

--- a/src/main/java/zmaster587/advancedRocketry/network/PacketLaserGun.java
+++ b/src/main/java/zmaster587/advancedRocketry/network/PacketLaserGun.java
@@ -25,9 +25,9 @@ public class PacketLaserGun extends BasePacket {
 	@Override
 	public void write(ByteBuf out) {
 		out.writeInt(fromEntity.getEntityId());
-		out.writeFloat((float)toPos.xCoord);
-		out.writeFloat((float)toPos.yCoord);
-		out.writeFloat((float)toPos.zCoord);
+		out.writeFloat((float)toPos.x);
+		out.writeFloat((float)toPos.y);
+		out.writeFloat((float)toPos.z);
 	}
 
 	@Override

--- a/src/main/java/zmaster587/advancedRocketry/satellite/SatelliteData.java
+++ b/src/main/java/zmaster587/advancedRocketry/satellite/SatelliteData.java
@@ -109,7 +109,7 @@ public abstract class SatelliteData extends SatelliteBase {
 
 	@Override
 	public void sendChanges(Container container, IContainerListener crafter, int variableId, int localId) {
-		crafter.sendProgressBarUpdate(container, variableId, (short)(( lastActionTime >>> (localId*16) ) & 0xffff));
+		crafter.sendWindowProperty(container, variableId, (short)(( lastActionTime >>> (localId*16) ) & 0xffff));
 
 		if(localId == 3)
 			prevLastActionTime=lastActionTime;

--- a/src/main/java/zmaster587/advancedRocketry/satellite/SpySatellite.java
+++ b/src/main/java/zmaster587/advancedRocketry/satellite/SpySatellite.java
@@ -46,7 +46,7 @@ public class SpySatellite extends SatelliteBase {
 			worldserver.getEntityTracker().removePlayerFromTrackers((EntityPlayerMP) player);
 			worldserver.getEntityTracker().removeEntityFromAllTrackingPlayers((EntityPlayerMP) player);
 			//((EntityPlayerMP)player).getServerForPlayer().getPlayerManager().removePlayer((EntityPlayerMP) player);
-			//MinecraftServer.getServer().worldServerForDimension(player.dimension).removePlayerEntityDangerously(player);
+			//MinecraftServer.getServer().getWorld(player.dimension).removePlayerEntityDangerously(player);
 
 			//MinecraftServer.getServer().getConfigurationManager().playerEntityList.remove(player);
 			//worldserver.removePlayerEntityDangerously(player);

--- a/src/main/java/zmaster587/advancedRocketry/tile/station/TileWarpShipMonitor.java
+++ b/src/main/java/zmaster587/advancedRocketry/tile/station/TileWarpShipMonitor.java
@@ -1,27 +1,33 @@
 package zmaster587.advancedRocketry.tile.station;
 
-import io.netty.buffer.ByteBuf;
-
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
 import com.google.common.base.Predicate;
 
-import zmaster587.advancedRocketry.AdvancedRocketry;
-import zmaster587.advancedRocketry.achievements.ARAchivements;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.ITickable;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.MathHelper;
+import net.minecraftforge.fml.relauncher.Side;
 import zmaster587.advancedRocketry.api.Configuration;
-import zmaster587.advancedRocketry.api.DataStorage;
 import zmaster587.advancedRocketry.api.DataStorage.DataType;
 import zmaster587.advancedRocketry.api.dimension.IDimensionProperties;
 import zmaster587.advancedRocketry.api.dimension.solar.StellarBody;
-import zmaster587.advancedRocketry.api.satellite.IDataHandler;
 import zmaster587.advancedRocketry.api.stations.ISpaceObject;
+import zmaster587.advancedRocketry.dimension.DimensionManager;
+import zmaster587.advancedRocketry.dimension.DimensionProperties;
+import zmaster587.advancedRocketry.inventory.IPlanetDefiner;
+import zmaster587.advancedRocketry.inventory.TextureResources;
 import zmaster587.advancedRocketry.inventory.modules.ModuleData;
 import zmaster587.advancedRocketry.inventory.modules.ModulePanetImage;
 import zmaster587.advancedRocketry.inventory.modules.ModulePlanetSelector;
-import zmaster587.advancedRocketry.inventory.IPlanetDefiner;
-import zmaster587.advancedRocketry.inventory.TextureResources;
 import zmaster587.advancedRocketry.item.ItemData;
 import zmaster587.advancedRocketry.item.ItemPlanetIdentificationChip;
 import zmaster587.advancedRocketry.network.PacketSpaceStationInfo;
@@ -29,13 +35,9 @@ import zmaster587.advancedRocketry.stations.SpaceObject;
 import zmaster587.advancedRocketry.stations.SpaceObjectManager;
 import zmaster587.advancedRocketry.tile.multiblock.TileWarpCore;
 import zmaster587.advancedRocketry.util.IDataInventory;
-import zmaster587.advancedRocketry.util.ITilePlanetSystemSelectable;
 import zmaster587.advancedRocketry.world.util.MultiData;
-import zmaster587.advancedRocketry.dimension.DimensionManager;
-import zmaster587.advancedRocketry.dimension.DimensionProperties;
 import zmaster587.libVulpes.LibVulpes;
 import zmaster587.libVulpes.client.util.IndicatorBarImage;
-import zmaster587.libVulpes.client.util.ProgressBarImage;
 import zmaster587.libVulpes.inventory.GuiHandler;
 import zmaster587.libVulpes.inventory.GuiHandler.guiId;
 import zmaster587.libVulpes.inventory.modules.IButtonInventory;
@@ -46,7 +48,6 @@ import zmaster587.libVulpes.inventory.modules.IProgressBar;
 import zmaster587.libVulpes.inventory.modules.ISelectionNotify;
 import zmaster587.libVulpes.inventory.modules.ModuleBase;
 import zmaster587.libVulpes.inventory.modules.ModuleButton;
-import zmaster587.libVulpes.inventory.modules.ModuleImage;
 import zmaster587.libVulpes.inventory.modules.ModuleProgress;
 import zmaster587.libVulpes.inventory.modules.ModuleScaledImage;
 import zmaster587.libVulpes.inventory.modules.ModuleSlotArray;
@@ -59,17 +60,6 @@ import zmaster587.libVulpes.network.PacketMachine;
 import zmaster587.libVulpes.util.EmbeddedInventory;
 import zmaster587.libVulpes.util.HashedBlockPosition;
 import zmaster587.libVulpes.util.INetworkMachine;
-import zmaster587.libVulpes.util.IconResource;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.network.Packet;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
-import net.minecraft.util.ITickable;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.math.MathHelper;
-import net.minecraftforge.fml.relauncher.Side;
 
 public class TileWarpShipMonitor extends TileEntity implements ITickable, IModularInventory, ISelectionNotify, INetworkMachine, IButtonInventory, IProgressBar, IDataSync, IGuiCallback, IDataInventory, IPlanetDefiner {
 
@@ -476,9 +466,9 @@ public class TileWarpShipMonitor extends TileEntity implements ITickable, IModul
 						return SpaceObjectManager.getSpaceManager().getSpaceStationFromBlockCoords(input.getPosition()) == station;
 					};
 				})) {
-					player2.addStat(ARAchivements.givingItAllShesGot);
-					if(!DimensionManager.hasReachedWarp)
-						player2.addStat(ARAchivements.flightOfThePhoenix);
+//					player2.addStat(ARAchivements.givingItAllShesGot);//TODO Advancment trigger
+//					if(!DimensionManager.hasReachedWarp)
+//						player2.addStat(ARAchivements.flightOfThePhoenix);
 				}
 
 				DimensionManager.hasReachedWarp = true;

--- a/src/main/java/zmaster587/advancedRocketry/util/GravityHandler.java
+++ b/src/main/java/zmaster587/advancedRocketry/util/GravityHandler.java
@@ -11,6 +11,7 @@ import zmaster587.advancedRocketry.api.IPlanetaryProvider;
 import zmaster587.advancedRocketry.dimension.DimensionManager;
 import zmaster587.advancedRocketry.world.provider.WorldProviderSpace;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.EnumFacing;
@@ -43,8 +44,7 @@ public class GravityHandler implements IGravityManager {
 	private static WeakHashMap<Entity, Double> entityMap = new WeakHashMap<Entity, Double>();
 
 	public static void applyGravity(Entity entity) {
-		
-		
+
 		if(!entity.isInWater() || entity instanceof EntityItem) {
 			if(!(entity instanceof EntityPlayer) || !((EntityPlayer)entity).capabilities.isFlying) {
 				Double d;
@@ -63,11 +63,10 @@ public class GravityHandler implements IGravityManager {
 						gravMult = ((IPlanetaryProvider)entity.world.provider).getGravitationalMultiplier(entity.getPosition());
 					else
 						gravMult = DimensionManager.getInstance().getDimensionProperties(entity.world.provider.getDimension()).gravitationalMultiplier;
-
 					if(entity instanceof EntityItem)
 						entity.motionY -= gravMult*ITEM_GRAV_OFFSET;
-					else
-						entity.motionY -= gravMult*ENTITY_OFFSET;
+					else//Not-Items are not ASMed, so they have to subtract the original gravity.
+						entity.motionY -= (gravMult*ENTITY_OFFSET - ENTITY_OFFSET);
 					return;
 				}
 				else {
@@ -81,6 +80,7 @@ public class GravityHandler implements IGravityManager {
 						}
 					}
 					else {
+	                    if(entity instanceof EntityPlayer) System.out.println("test");
 						if(entity instanceof EntityItem)
 							entity.motionY -= ITEM_GRAV_OFFSET;
 						else

--- a/src/main/java/zmaster587/advancedRocketry/util/GravityHandler.java
+++ b/src/main/java/zmaster587/advancedRocketry/util/GravityHandler.java
@@ -80,7 +80,6 @@ public class GravityHandler implements IGravityManager {
 						}
 					}
 					else {
-	                    if(entity instanceof EntityPlayer) System.out.println("test");
 						if(entity instanceof EntityItem)
 							entity.motionY -= ITEM_GRAV_OFFSET;
 						else

--- a/src/main/java/zmaster587/advancedRocketry/util/MobileAABB.java
+++ b/src/main/java/zmaster587/advancedRocketry/util/MobileAABB.java
@@ -280,7 +280,7 @@ public class MobileAABB extends AxisAlignedBB {
 	}
 
 	@Override
-	public boolean intersectsWith(AxisAlignedBB aabb) {
+	public boolean intersects(AxisAlignedBB aabb) {
 
 		//if(chunk == null || true)
 		//	return super.intersectsWith(aabb);
@@ -308,7 +308,7 @@ public class MobileAABB extends AxisAlignedBB {
 
 
 						bb = bb.offset(this.minX + x + diffX, this.minY + y, this.minZ + z + diffZ);
-						if(bb.intersectsWith(aabb)) {
+						if(bb.intersects(aabb)) {
 							collides = true;
 							break out;
 						}

--- a/src/main/java/zmaster587/advancedRocketry/util/RecipeHandler.java
+++ b/src/main/java/zmaster587/advancedRocketry/util/RecipeHandler.java
@@ -71,139 +71,139 @@ public class RecipeHandler {
 	}
 	
 	public void createAutoGennedRecipes(HashMap<AllowedProducts, HashSet<String>> modProducts) {
-		//AutoGenned Recipes
-		for(zmaster587.libVulpes.api.material.Material ore : MaterialRegistry.getAllMaterials()) {
-			if(AllowedProducts.getProductByName("ORE").isOfType(ore.getAllowedProducts()) && AllowedProducts.getProductByName("INGOT").isOfType(ore.getAllowedProducts()))
-				GameRegistry.addSmelting(ore.getProduct(AllowedProducts.getProductByName("ORE")), ore.getProduct(AllowedProducts.getProductByName("INGOT")), 0);
-
-			if(AllowedProducts.getProductByName("NUGGET").isOfType(ore.getAllowedProducts())) {
-				ItemStack nugget = ore.getProduct(AllowedProducts.getProductByName("NUGGET"));
-				nugget.setCount(9);
-				for(String str : ore.getOreDictNames()) {
-					GameRegistry.addRecipe(new ShapelessOreRecipe(nugget, AllowedProducts.getProductByName("INGOT").name().toLowerCase(Locale.ENGLISH) + str));
-					GameRegistry.addRecipe(new ShapedOreRecipe(ore.getProduct(AllowedProducts.getProductByName("INGOT")), "ooo", "ooo", "ooo", 'o', AllowedProducts.getProductByName("NUGGET").name().toLowerCase(Locale.ENGLISH) + str));
-				}
-			}
-
-			if(AllowedProducts.getProductByName("CRYSTAL").isOfType(ore.getAllowedProducts())) {
-				for(String str : ore.getOreDictNames())
-					RecipesMachine.getInstance().addRecipe(TileCrystallizer.class, ore.getProduct(AllowedProducts.getProductByName("CRYSTAL")), 300, 20, AllowedProducts.getProductByName("DUST").name().toLowerCase(Locale.ENGLISH) + str);
-			}
-
-			if(AllowedProducts.getProductByName("BOULE").isOfType(ore.getAllowedProducts())) {
-				for(String str : ore.getOreDictNames())
-					RecipesMachine.getInstance().addRecipe(TileCrystallizer.class, ore.getProduct(AllowedProducts.getProductByName("BOULE")), 300, 20, AllowedProducts.getProductByName("INGOT").name().toLowerCase(Locale.ENGLISH) + str, AllowedProducts.getProductByName("NUGGET").name().toLowerCase(Locale.ENGLISH) + str);
-			}
-
-			if(AllowedProducts.getProductByName("STICK").isOfType(ore.getAllowedProducts()) && AllowedProducts.getProductByName("INGOT").isOfType(ore.getAllowedProducts())) {
-				for(String name : ore.getOreDictNames())
-					if(OreDictionary.doesOreNameExist(AllowedProducts.getProductByName("INGOT").name().toLowerCase(Locale.ENGLISH) + name)) {
-
-						GameRegistry.addRecipe(new ShapedOreRecipe(ore.getProduct(AllowedProducts.getProductByName("STICK"),4), "x  ", " x ", "  x", 'x', AllowedProducts.getProductByName("INGOT").name().toLowerCase(Locale.ENGLISH) + name));
-
-						RecipesMachine.getInstance().addRecipe(TileLathe.class, ore.getProduct(AllowedProducts.getProductByName("STICK"),2), 300, 20, AllowedProducts.getProductByName("INGOT").name().toLowerCase(Locale.ENGLISH) + name); //ore.getProduct(AllowedProducts.getProductByName("INGOT")));
-					}
-			}
-
-			if(AllowedProducts.getProductByName("PLATE").isOfType(ore.getAllowedProducts())) {
-				for(String oreDictNames : ore.getOreDictNames()) {
-					if(OreDictionary.doesOreNameExist(AllowedProducts.getProductByName("INGOT").name().toLowerCase(Locale.ENGLISH) + oreDictNames)) {
-						RecipesMachine.getInstance().addRecipe(TileRollingMachine.class, ore.getProduct(AllowedProducts.getProductByName("PLATE")), 300, 20, AllowedProducts.getProductByName("INGOT").name().toLowerCase(Locale.ENGLISH) + oreDictNames, new FluidStack(FluidRegistry.WATER, 100));
-						if(AllowedProducts.getProductByName("BLOCK").isOfType(ore.getAllowedProducts()) || ore.isVanilla())
-							RecipesMachine.getInstance().addRecipe(BlockPress.class, ore.getProduct(AllowedProducts.getProductByName("PLATE"),4), 0, 0, AllowedProducts.getProductByName("BLOCK").name().toLowerCase(Locale.ENGLISH) + oreDictNames);
-					}
-				}
-			}
-
-			if(AllowedProducts.getProductByName("SHEET").isOfType(ore.getAllowedProducts())) {
-				for(String oreDictNames : ore.getOreDictNames()) {
-					RecipesMachine.getInstance().addRecipe(TileRollingMachine.class, ore.getProduct(AllowedProducts.getProductByName("SHEET")), 300, 200, AllowedProducts.getProductByName("PLATE").name().toLowerCase(Locale.ENGLISH) + oreDictNames, new FluidStack(FluidRegistry.WATER, 100));
-				}
-			}
-
-			if(AllowedProducts.getProductByName("COIL").isOfType(ore.getAllowedProducts())) {
-				for(String str : ore.getOreDictNames())
-					GameRegistry.addRecipe(new ShapedOreRecipe(ore.getProduct(AllowedProducts.getProductByName("COIL")), "ooo", "o o", "ooo",'o', AllowedProducts.getProductByName("INGOT").name().toLowerCase(Locale.ENGLISH) + str));
-			}
-
-			if(AllowedProducts.getProductByName("FAN").isOfType(ore.getAllowedProducts())) {
-				for(String str : ore.getOreDictNames()) {
-					GameRegistry.addRecipe(new ShapedOreRecipe(ore.getProduct(AllowedProducts.getProductByName("FAN")), "p p", " r ", "p p", 'p', AllowedProducts.getProductByName("PLATE").name().toLowerCase(Locale.ENGLISH) + str, 'r', AllowedProducts.getProductByName("STICK").name().toLowerCase(Locale.ENGLISH) + str));
-				}
-			}
-			if(AllowedProducts.getProductByName("GEAR").isOfType(ore.getAllowedProducts())) {
-				for(String str : ore.getOreDictNames()) {
-					GameRegistry.addRecipe(new ShapedOreRecipe(ore.getProduct(AllowedProducts.getProductByName("GEAR")), "sps", " r ", "sps", 'p', AllowedProducts.getProductByName("PLATE").name().toLowerCase(Locale.ENGLISH) + str, 's', AllowedProducts.getProductByName("STICK").name().toLowerCase(Locale.ENGLISH) + str, 'r', AllowedProducts.getProductByName("INGOT").name().toLowerCase(Locale.ENGLISH) + str));
-				}
-			}
-			if(AllowedProducts.getProductByName("BLOCK").isOfType(ore.getAllowedProducts())) {
-				ItemStack ingot = ore.getProduct(AllowedProducts.getProductByName("INGOT"));
-				ingot.setCount(9);
-				for(String str : ore.getOreDictNames()) {
-					GameRegistry.addRecipe(new ShapelessOreRecipe(ingot, AllowedProducts.getProductByName("BLOCK").name().toLowerCase(Locale.ENGLISH) + str));
-					GameRegistry.addRecipe(new ShapedOreRecipe(ore.getProduct(AllowedProducts.getProductByName("BLOCK")), "ooo", "ooo", "ooo", 'o', AllowedProducts.getProductByName("INGOT").name().toLowerCase(Locale.ENGLISH) + str));
-				}
-			}
-
-			if(AllowedProducts.getProductByName("DUST").isOfType(ore.getAllowedProducts())) {
-				for(String str : ore.getOreDictNames()) {
-					if(AllowedProducts.getProductByName("ORE").isOfType(ore.getAllowedProducts()) || ore.isVanilla()) {
-						ItemStack stack = ore.getProduct(AllowedProducts.getProductByName("DUST"));
-						stack.setCount(2);
-						RecipesMachine.getInstance().addRecipe(BlockPress.class, stack, 0, 0, AllowedProducts.getProductByName("ORE").name().toLowerCase(Locale.ENGLISH) + str);
-					}
-					if(AllowedProducts.getProductByName("INGOT").isOfType(ore.getAllowedProducts()) || ore.isVanilla())
-						GameRegistry.addSmelting(ore.getProduct(AllowedProducts.getProductByName("DUST")), ore.getProduct(AllowedProducts.getProductByName("INGOT")), 0);
-				}
-			}
-		}
-
-		//Handle vanilla integration
-		if(zmaster587.advancedRocketry.api.Configuration.allowSawmillVanillaWood) {
-			for(int i = 0; i < 4; i++) {
-				RecipesMachine.getInstance().addRecipe(TileCuttingMachine.class, new ItemStack(Blocks.PLANKS, 6, i), 80, 10, new ItemStack(Blocks.LOG,1, i));
-			}
-			RecipesMachine.getInstance().addRecipe(TileCuttingMachine.class, new ItemStack(Blocks.PLANKS, 6, 4), 80, 10, new ItemStack(Blocks.LOG2,1, 0));
-			RecipesMachine.getInstance().addRecipe(TileCuttingMachine.class, new ItemStack(Blocks.PLANKS, 6, 5), 80, 10, new ItemStack(Blocks.LOG2,1, 1));
-		}
-
-		//Handle items from other mods
-		if(zmaster587.advancedRocketry.api.Configuration.allowMakingItemsForOtherMods) {
-			for(Entry<AllowedProducts, HashSet<String>> entry : modProducts.entrySet()) {
-				if(entry.getKey() == AllowedProducts.getProductByName("PLATE")) {
-					for(String str : entry.getValue()) {
-						zmaster587.libVulpes.api.material.Material material = zmaster587.libVulpes.api.material.Material.valueOfSafe(str.toUpperCase());
-
-						if(OreDictionary.doesOreNameExist("ingot" + str) && OreDictionary.getOres("ingot" + str).size() > 0 && (material == null || !AllowedProducts.getProductByName("PLATE").isOfType(material.getAllowedProducts())) ) {
-
-							RecipesMachine.getInstance().addRecipe(TileRollingMachine.class, OreDictionary.getOres("plate" + str).get(0), 300, 20, "ingot" + str);
-						}
-					}
-				}
-				else if(entry.getKey() == AllowedProducts.getProductByName("STICK")) {
-					for(String str : entry.getValue()) {
-						zmaster587.libVulpes.api.material.Material material = zmaster587.libVulpes.api.material.Material.valueOfSafe(str.toUpperCase());
-
-						if(OreDictionary.doesOreNameExist("ingot" + str) && OreDictionary.getOres("ingot" + str).size() > 0 && (material == null || !AllowedProducts.getProductByName("STICK").isOfType(material.getAllowedProducts())) ) {
-
-							//GT registers rods as sticks
-							ItemStack stackToAdd = null;
-							if(OreDictionary.doesOreNameExist("rod" + str) && OreDictionary.getOres("rod" + str).size() > 0) {
-								stackToAdd = OreDictionary.getOres("rod" + str).get(0).copy();
-								stackToAdd.setCount(2);
-							}
-							else if(OreDictionary.doesOreNameExist("stick" + str)  && OreDictionary.getOres("stick" + str).size() > 0) {
-								stackToAdd = OreDictionary.getOres("stick" + str).get(0).copy();
-								stackToAdd.setCount(2);
-								}
-							else 
-								continue;
-
-							RecipesMachine.getInstance().addRecipe(TileLathe.class, stackToAdd, 300, 20, "ingot" + str);
-						}
-					}
-				}
-			}
-		}
+//		//AutoGenned Recipes TODO Recipes
+//		for(zmaster587.libVulpes.api.material.Material ore : MaterialRegistry.getAllMaterials()) {
+//			if(AllowedProducts.getProductByName("ORE").isOfType(ore.getAllowedProducts()) && AllowedProducts.getProductByName("INGOT").isOfType(ore.getAllowedProducts()))
+//				GameRegistry.addSmelting(ore.getProduct(AllowedProducts.getProductByName("ORE")), ore.getProduct(AllowedProducts.getProductByName("INGOT")), 0);
+//
+//			if(AllowedProducts.getProductByName("NUGGET").isOfType(ore.getAllowedProducts())) {
+//				ItemStack nugget = ore.getProduct(AllowedProducts.getProductByName("NUGGET"));
+//				nugget.setCount(9);
+//				for(String str : ore.getOreDictNames()) {
+//					GameRegistry.addRecipe(new ShapelessOreRecipe(nugget, AllowedProducts.getProductByName("INGOT").name().toLowerCase(Locale.ENGLISH) + str));
+//					GameRegistry.addRecipe(new ShapedOreRecipe(ore.getProduct(AllowedProducts.getProductByName("INGOT")), "ooo", "ooo", "ooo", 'o', AllowedProducts.getProductByName("NUGGET").name().toLowerCase(Locale.ENGLISH) + str));
+//				}
+//			}
+//
+//			if(AllowedProducts.getProductByName("CRYSTAL").isOfType(ore.getAllowedProducts())) {
+//				for(String str : ore.getOreDictNames())
+//					RecipesMachine.getInstance().addRecipe(TileCrystallizer.class, ore.getProduct(AllowedProducts.getProductByName("CRYSTAL")), 300, 20, AllowedProducts.getProductByName("DUST").name().toLowerCase(Locale.ENGLISH) + str);
+//			}
+//
+//			if(AllowedProducts.getProductByName("BOULE").isOfType(ore.getAllowedProducts())) {
+//				for(String str : ore.getOreDictNames())
+//					RecipesMachine.getInstance().addRecipe(TileCrystallizer.class, ore.getProduct(AllowedProducts.getProductByName("BOULE")), 300, 20, AllowedProducts.getProductByName("INGOT").name().toLowerCase(Locale.ENGLISH) + str, AllowedProducts.getProductByName("NUGGET").name().toLowerCase(Locale.ENGLISH) + str);
+//			}
+//
+//			if(AllowedProducts.getProductByName("STICK").isOfType(ore.getAllowedProducts()) && AllowedProducts.getProductByName("INGOT").isOfType(ore.getAllowedProducts())) {
+//				for(String name : ore.getOreDictNames())
+//					if(OreDictionary.doesOreNameExist(AllowedProducts.getProductByName("INGOT").name().toLowerCase(Locale.ENGLISH) + name)) {
+//
+//						GameRegistry.addRecipe(new ShapedOreRecipe(ore.getProduct(AllowedProducts.getProductByName("STICK"),4), "x  ", " x ", "  x", 'x', AllowedProducts.getProductByName("INGOT").name().toLowerCase(Locale.ENGLISH) + name));
+//
+//						RecipesMachine.getInstance().addRecipe(TileLathe.class, ore.getProduct(AllowedProducts.getProductByName("STICK"),2), 300, 20, AllowedProducts.getProductByName("INGOT").name().toLowerCase(Locale.ENGLISH) + name); //ore.getProduct(AllowedProducts.getProductByName("INGOT")));
+//					}
+//			}
+//
+//			if(AllowedProducts.getProductByName("PLATE").isOfType(ore.getAllowedProducts())) {
+//				for(String oreDictNames : ore.getOreDictNames()) {
+//					if(OreDictionary.doesOreNameExist(AllowedProducts.getProductByName("INGOT").name().toLowerCase(Locale.ENGLISH) + oreDictNames)) {
+//						RecipesMachine.getInstance().addRecipe(TileRollingMachine.class, ore.getProduct(AllowedProducts.getProductByName("PLATE")), 300, 20, AllowedProducts.getProductByName("INGOT").name().toLowerCase(Locale.ENGLISH) + oreDictNames, new FluidStack(FluidRegistry.WATER, 100));
+//						if(AllowedProducts.getProductByName("BLOCK").isOfType(ore.getAllowedProducts()) || ore.isVanilla())
+//							RecipesMachine.getInstance().addRecipe(BlockPress.class, ore.getProduct(AllowedProducts.getProductByName("PLATE"),4), 0, 0, AllowedProducts.getProductByName("BLOCK").name().toLowerCase(Locale.ENGLISH) + oreDictNames);
+//					}
+//				}
+//			}
+//
+//			if(AllowedProducts.getProductByName("SHEET").isOfType(ore.getAllowedProducts())) {
+//				for(String oreDictNames : ore.getOreDictNames()) {
+//					RecipesMachine.getInstance().addRecipe(TileRollingMachine.class, ore.getProduct(AllowedProducts.getProductByName("SHEET")), 300, 200, AllowedProducts.getProductByName("PLATE").name().toLowerCase(Locale.ENGLISH) + oreDictNames, new FluidStack(FluidRegistry.WATER, 100));
+//				}
+//			}
+//
+//			if(AllowedProducts.getProductByName("COIL").isOfType(ore.getAllowedProducts())) {
+//				for(String str : ore.getOreDictNames())
+//					GameRegistry.addRecipe(new ShapedOreRecipe(ore.getProduct(AllowedProducts.getProductByName("COIL")), "ooo", "o o", "ooo",'o', AllowedProducts.getProductByName("INGOT").name().toLowerCase(Locale.ENGLISH) + str));
+//			}
+//
+//			if(AllowedProducts.getProductByName("FAN").isOfType(ore.getAllowedProducts())) {
+//				for(String str : ore.getOreDictNames()) {
+//					GameRegistry.addRecipe(new ShapedOreRecipe(ore.getProduct(AllowedProducts.getProductByName("FAN")), "p p", " r ", "p p", 'p', AllowedProducts.getProductByName("PLATE").name().toLowerCase(Locale.ENGLISH) + str, 'r', AllowedProducts.getProductByName("STICK").name().toLowerCase(Locale.ENGLISH) + str));
+//				}
+//			}
+//			if(AllowedProducts.getProductByName("GEAR").isOfType(ore.getAllowedProducts())) {
+//				for(String str : ore.getOreDictNames()) {
+//					GameRegistry.addRecipe(new ShapedOreRecipe(ore.getProduct(AllowedProducts.getProductByName("GEAR")), "sps", " r ", "sps", 'p', AllowedProducts.getProductByName("PLATE").name().toLowerCase(Locale.ENGLISH) + str, 's', AllowedProducts.getProductByName("STICK").name().toLowerCase(Locale.ENGLISH) + str, 'r', AllowedProducts.getProductByName("INGOT").name().toLowerCase(Locale.ENGLISH) + str));
+//				}
+//			}
+//			if(AllowedProducts.getProductByName("BLOCK").isOfType(ore.getAllowedProducts())) {
+//				ItemStack ingot = ore.getProduct(AllowedProducts.getProductByName("INGOT"));
+//				ingot.setCount(9);
+//				for(String str : ore.getOreDictNames()) {
+//					GameRegistry.addRecipe(new ShapelessOreRecipe(ingot, AllowedProducts.getProductByName("BLOCK").name().toLowerCase(Locale.ENGLISH) + str));
+//					GameRegistry.addRecipe(new ShapedOreRecipe(ore.getProduct(AllowedProducts.getProductByName("BLOCK")), "ooo", "ooo", "ooo", 'o', AllowedProducts.getProductByName("INGOT").name().toLowerCase(Locale.ENGLISH) + str));
+//				}
+//			}
+//
+//			if(AllowedProducts.getProductByName("DUST").isOfType(ore.getAllowedProducts())) {
+//				for(String str : ore.getOreDictNames()) {
+//					if(AllowedProducts.getProductByName("ORE").isOfType(ore.getAllowedProducts()) || ore.isVanilla()) {
+//						ItemStack stack = ore.getProduct(AllowedProducts.getProductByName("DUST"));
+//						stack.setCount(2);
+//						RecipesMachine.getInstance().addRecipe(BlockPress.class, stack, 0, 0, AllowedProducts.getProductByName("ORE").name().toLowerCase(Locale.ENGLISH) + str);
+//					}
+//					if(AllowedProducts.getProductByName("INGOT").isOfType(ore.getAllowedProducts()) || ore.isVanilla())
+//						GameRegistry.addSmelting(ore.getProduct(AllowedProducts.getProductByName("DUST")), ore.getProduct(AllowedProducts.getProductByName("INGOT")), 0);
+//				}
+//			}
+//		}
+//
+//		//Handle vanilla integration
+//		if(zmaster587.advancedRocketry.api.Configuration.allowSawmillVanillaWood) {
+//			for(int i = 0; i < 4; i++) {
+//				RecipesMachine.getInstance().addRecipe(TileCuttingMachine.class, new ItemStack(Blocks.PLANKS, 6, i), 80, 10, new ItemStack(Blocks.LOG,1, i));
+//			}
+//			RecipesMachine.getInstance().addRecipe(TileCuttingMachine.class, new ItemStack(Blocks.PLANKS, 6, 4), 80, 10, new ItemStack(Blocks.LOG2,1, 0));
+//			RecipesMachine.getInstance().addRecipe(TileCuttingMachine.class, new ItemStack(Blocks.PLANKS, 6, 5), 80, 10, new ItemStack(Blocks.LOG2,1, 1));
+//		}
+//
+//		//Handle items from other mods
+//		if(zmaster587.advancedRocketry.api.Configuration.allowMakingItemsForOtherMods) {
+//			for(Entry<AllowedProducts, HashSet<String>> entry : modProducts.entrySet()) {
+//				if(entry.getKey() == AllowedProducts.getProductByName("PLATE")) {
+//					for(String str : entry.getValue()) {
+//						zmaster587.libVulpes.api.material.Material material = zmaster587.libVulpes.api.material.Material.valueOfSafe(str.toUpperCase());
+//
+//						if(OreDictionary.doesOreNameExist("ingot" + str) && OreDictionary.getOres("ingot" + str).size() > 0 && (material == null || !AllowedProducts.getProductByName("PLATE").isOfType(material.getAllowedProducts())) ) {
+//
+//							RecipesMachine.getInstance().addRecipe(TileRollingMachine.class, OreDictionary.getOres("plate" + str).get(0), 300, 20, "ingot" + str);
+//						}
+//					}
+//				}
+//				else if(entry.getKey() == AllowedProducts.getProductByName("STICK")) {
+//					for(String str : entry.getValue()) {
+//						zmaster587.libVulpes.api.material.Material material = zmaster587.libVulpes.api.material.Material.valueOfSafe(str.toUpperCase());
+//
+//						if(OreDictionary.doesOreNameExist("ingot" + str) && OreDictionary.getOres("ingot" + str).size() > 0 && (material == null || !AllowedProducts.getProductByName("STICK").isOfType(material.getAllowedProducts())) ) {
+//
+//							//GT registers rods as sticks
+//							ItemStack stackToAdd = null;
+//							if(OreDictionary.doesOreNameExist("rod" + str) && OreDictionary.getOres("rod" + str).size() > 0) {
+//								stackToAdd = OreDictionary.getOres("rod" + str).get(0).copy();
+//								stackToAdd.setCount(2);
+//							}
+//							else if(OreDictionary.doesOreNameExist("stick" + str)  && OreDictionary.getOres("stick" + str).size() > 0) {
+//								stackToAdd = OreDictionary.getOres("stick" + str).get(0).copy();
+//								stackToAdd.setCount(2);
+//								}
+//							else 
+//								continue;
+//
+//							RecipesMachine.getInstance().addRecipe(TileLathe.class, stackToAdd, 300, 20, "ingot" + str);
+//						}
+//					}
+//				}
+//			}
+//		}
 	}
 }

--- a/src/main/java/zmaster587/advancedRocketry/world/ChunkManagerPlanet.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/ChunkManagerPlanet.java
@@ -1,17 +1,11 @@
 package zmaster587.advancedRocketry.world;
 
-import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
-
 import java.lang.reflect.Field;
 import java.util.List;
 
 import javax.annotation.Nullable;
 
-import zmaster587.advancedRocketry.AdvancedRocketry;
-import zmaster587.advancedRocketry.api.AdvancedRocketryBiomes;
-import zmaster587.advancedRocketry.dimension.DimensionManager;
-import zmaster587.advancedRocketry.dimension.DimensionProperties;
-import zmaster587.advancedRocketry.world.type.WorldTypePlanetGen;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import net.minecraft.crash.CrashReport;
 import net.minecraft.crash.CrashReportCategory;
 import net.minecraft.init.Biomes;
@@ -21,7 +15,7 @@ import net.minecraft.world.WorldType;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.BiomeCache;
 import net.minecraft.world.biome.BiomeProvider;
-import net.minecraft.world.gen.ChunkProviderSettings;
+import net.minecraft.world.gen.ChunkGeneratorSettings;
 import net.minecraft.world.gen.layer.GenLayer;
 import net.minecraft.world.gen.layer.GenLayerAddIsland;
 import net.minecraft.world.gen.layer.GenLayerAddMushroomIsland;
@@ -43,6 +37,10 @@ import net.minecraft.world.gen.layer.GenLayerZoom;
 import net.minecraft.world.gen.layer.IntCache;
 import net.minecraftforge.common.BiomeManager.BiomeEntry;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
+import zmaster587.advancedRocketry.AdvancedRocketry;
+import zmaster587.advancedRocketry.dimension.DimensionManager;
+import zmaster587.advancedRocketry.dimension.DimensionProperties;
+import zmaster587.advancedRocketry.world.type.WorldTypePlanetGen;
 
 public class ChunkManagerPlanet extends BiomeProvider {
 	//TODO: make higher biome ids work
@@ -116,11 +114,11 @@ public class ChunkManagerPlanet extends BiomeProvider {
 		GenLayer genlayer4 = GenLayerZoom.magnify(1000L, genlayerdeepocean, 0);
 		int i = 4;
 		int j = i;
-		ChunkProviderSettings chunkprovidersettings = null;
+		ChunkGeneratorSettings chunkprovidersettings = null;
 		
 		
 		if(!p_180781_3_.isEmpty()) {
-			chunkprovidersettings = ChunkProviderSettings.Factory.jsonToFactory(p_180781_3_).build();
+			chunkprovidersettings = ChunkGeneratorSettings.Factory.jsonToFactory(p_180781_3_).build();
 		}
 
 		if (p_180781_2_ == WorldType.CUSTOMIZED && !p_180781_3_.isEmpty())

--- a/src/main/java/zmaster587/advancedRocketry/world/ChunkProviderPlanet.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/ChunkProviderPlanet.java
@@ -10,15 +10,6 @@ import static net.minecraftforge.event.terraingen.InitMapGenEvent.EventType.VILL
 import java.util.List;
 import java.util.Random;
 
-import zmaster587.advancedRocketry.api.Configuration;
-import zmaster587.advancedRocketry.dimension.DimensionManager;
-import zmaster587.advancedRocketry.event.PlanetEventHandler;
-import zmaster587.advancedRocketry.util.OreGenProperties;
-import zmaster587.advancedRocketry.util.OreGenProperties.OreEntry;
-import zmaster587.advancedRocketry.world.decoration.MapGenCrater;
-import zmaster587.advancedRocketry.world.decoration.MapGenGeode;
-import zmaster587.advancedRocketry.world.ore.CustomizableOreGen;
-import zmaster587.advancedRocketry.world.provider.WorldProviderPlanet;
 import net.minecraft.block.BlockFalling;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EnumCreatureType;
@@ -35,8 +26,8 @@ import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.Biome.SpawnListEntry;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkPrimer;
-import net.minecraft.world.chunk.IChunkGenerator;
-import net.minecraft.world.gen.ChunkProviderSettings;
+import net.minecraft.world.gen.ChunkGeneratorSettings;
+import net.minecraft.world.gen.IChunkGenerator;
 import net.minecraft.world.gen.MapGenBase;
 import net.minecraft.world.gen.MapGenCaves;
 import net.minecraft.world.gen.MapGenRavine;
@@ -50,6 +41,15 @@ import net.minecraft.world.gen.structure.MapGenStronghold;
 import net.minecraft.world.gen.structure.MapGenVillage;
 import net.minecraft.world.gen.structure.StructureOceanMonument;
 import net.minecraftforge.event.terraingen.TerrainGen;
+import zmaster587.advancedRocketry.api.Configuration;
+import zmaster587.advancedRocketry.dimension.DimensionManager;
+import zmaster587.advancedRocketry.event.PlanetEventHandler;
+import zmaster587.advancedRocketry.util.OreGenProperties;
+import zmaster587.advancedRocketry.util.OreGenProperties.OreEntry;
+import zmaster587.advancedRocketry.world.decoration.MapGenCrater;
+import zmaster587.advancedRocketry.world.decoration.MapGenGeode;
+import zmaster587.advancedRocketry.world.ore.CustomizableOreGen;
+import zmaster587.advancedRocketry.world.provider.WorldProviderPlanet;
 
 public class ChunkProviderPlanet implements IChunkGenerator {
 	/** RNG. */
@@ -67,7 +67,7 @@ public class ChunkProviderPlanet implements IChunkGenerator {
 	private final WorldType terrainType;
 	private final double[] heightMap;
 	private final float[] biomeWeights;
-	private ChunkProviderSettings settings;
+	private ChunkGeneratorSettings settings;
 	private IBlockState oceanBlock = Blocks.WATER.getDefaultState();
 	private double[] depthBuffer = new double[256];
 	private MapGenBase caveGenerator = new MapGenCaves();
@@ -123,7 +123,7 @@ public class ChunkProviderPlanet implements IChunkGenerator {
 
         if (p_i46668_5_ != null)
         {
-            this.settings = ChunkProviderSettings.Factory.jsonToFactory(p_i46668_5_).build();
+            this.settings = ChunkGeneratorSettings.Factory.jsonToFactory(p_i46668_5_).build();
             this.oceanBlock = this.settings.useLavaOceans ? Blocks.LAVA.getDefaultState() : Blocks.WATER.getDefaultState();
             worldIn.setSeaLevel(this.settings.seaLevel);
         }
@@ -246,7 +246,7 @@ public class ChunkProviderPlanet implements IChunkGenerator {
 	 * specified chunk from the map seed and chunk seed
 	 */
 	@Override
-	public Chunk provideChunk(int x, int z)
+	public Chunk generateChunk(int x, int z)
 	{
 		this.rand.setSeed((long)x * 341873128712L + (long)z * 132897987541L);
 		ChunkPrimer chunkprimer = new ChunkPrimer();
@@ -600,15 +600,23 @@ public class ChunkProviderPlanet implements IChunkGenerator {
 		return false;
 	}
 
-	
-	@Override
-	public BlockPos getStrongholdGen(World worldIn, String structureName,
-			BlockPos position, boolean p_180513_4_) {
-		return null;
-	}
-
 	@Override
 	public void recreateStructures(Chunk chunkIn, int x, int z) {
 		
 	}
+
+    @Override
+    public BlockPos getNearestStructurePos(World worldIn, String structureName, BlockPos position,
+            boolean findUnexplored)
+    {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public boolean isInsideStructure(World worldIn, String structureName, BlockPos pos)
+    {
+        // TODO Auto-generated method stub
+        return false;
+    }
 }

--- a/src/main/java/zmaster587/advancedRocketry/world/ChunkProviderSpace.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/ChunkProviderSpace.java
@@ -3,7 +3,6 @@ package zmaster587.advancedRocketry.world;
 import java.util.Arrays;
 import java.util.List;
 
-import zmaster587.advancedRocketry.api.AdvancedRocketryBiomes;
 import net.minecraft.block.Block;
 import net.minecraft.entity.EnumCreatureType;
 import net.minecraft.util.math.BlockPos;
@@ -12,7 +11,8 @@ import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.Biome.SpawnListEntry;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkPrimer;
-import net.minecraft.world.chunk.IChunkGenerator;
+import net.minecraft.world.gen.IChunkGenerator;
+import zmaster587.advancedRocketry.api.AdvancedRocketryBiomes;
 
 public class ChunkProviderSpace implements IChunkGenerator {
 
@@ -24,7 +24,7 @@ public class ChunkProviderSpace implements IChunkGenerator {
 	}
 
 	@Override
-	public Chunk provideChunk(int p_73154_1_, int p_73154_2_) {
+	public Chunk generateChunk(int p_73154_1_, int p_73154_2_) {
 		Block[] ablock = new Block[65536];
 		byte[] abyte = new byte[65536];
 		ChunkPrimer chunkprimer = new ChunkPrimer();
@@ -57,14 +57,23 @@ public class ChunkProviderSpace implements IChunkGenerator {
 	}
 
 	@Override
-	public BlockPos getStrongholdGen(World worldIn, String structureName,
-			BlockPos position, boolean bool) {
-		return null;
-	}
-
-	@Override
 	public void recreateStructures(Chunk chunkIn, int x, int z) {
 		
 	}
+
+    @Override
+    public BlockPos getNearestStructurePos(World worldIn, String structureName, BlockPos position,
+            boolean findUnexplored)
+    {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public boolean isInsideStructure(World worldIn, String structureName, BlockPos pos)
+    {
+        // TODO Auto-generated method stub
+        return false;
+    }
 
 }

--- a/src/main/java/zmaster587/advancedRocketry/world/biome/BiomeGenAlienForest.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/biome/BiomeGenAlienForest.java
@@ -5,6 +5,7 @@ import java.util.Random;
 import zmaster587.advancedRocketry.world.gen.WorldGenAlienTree;
 import zmaster587.advancedRocketry.world.gen.WorldGenNoTree;
 import net.minecraft.init.Blocks;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
@@ -18,7 +19,7 @@ public class BiomeGenAlienForest extends Biome {
 	public BiomeGenAlienForest(int biomeId, boolean register) {
 		super(new BiomeProperties("Alien Forest").setWaterColor(0x8888FF));
 
-		registerBiome(biomeId, "Alien Forest", this);
+        this.setRegistryName(new ResourceLocation("advancedrocketry:Alien Forest"));
 		
 		this.fillerBlock = Blocks.GRASS.getDefaultState();
 		this.decorator.grassPerChunk = 50;

--- a/src/main/java/zmaster587/advancedRocketry/world/biome/BiomeGenCrystal.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/biome/BiomeGenCrystal.java
@@ -6,6 +6,7 @@ import zmaster587.advancedRocketry.api.AdvancedRocketryBlocks;
 import zmaster587.advancedRocketry.world.decoration.MapGenLargeCrystal;
 import zmaster587.advancedRocketry.world.gen.WorldGenLargeCrystal;
 import net.minecraft.init.Blocks;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
@@ -20,15 +21,14 @@ public class BiomeGenCrystal extends Biome  {
 	
 	public BiomeGenCrystal(int biomeId, boolean register) {
 		super(new BiomeProperties("CrystalChasms").setHeightVariation(0.1f).setBaseHeight(1f).setRainfall(0.2f).setTemperature(0.1f));
-		
-		registerBiome(biomeId, "CrystalChasms", this);
-		
+
+        this.setRegistryName(new ResourceLocation("advancedrocketry:CrystalChasms"));
 		
 		topBlock = Blocks.SNOW.getDefaultState();
 		fillerBlock = Blocks.PACKED_ICE.getDefaultState();
 		this.spawnableMonsterList.clear();
 		this.spawnableCreatureList.clear();
-		this.decorator.generateLakes=false;
+		this.decorator.generateFalls=false;
 		this.decorator.flowersPerChunk=0;
 		this.decorator.grassPerChunk=0;
 		this.decorator.treesPerChunk=0;

--- a/src/main/java/zmaster587/advancedRocketry/world/biome/BiomeGenDeepSwamp.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/biome/BiomeGenDeepSwamp.java
@@ -11,6 +11,7 @@ import net.minecraft.block.BlockFlower.EnumFlowerType;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.monster.EntitySlime;
 import net.minecraft.init.Blocks;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
@@ -28,7 +29,7 @@ public class BiomeGenDeepSwamp extends Biome {
 	public BiomeGenDeepSwamp(int biomeId, boolean register) {
 		super(new BiomeProperties("DeepSwamp").setBaseHeight(-0.1f).setHeightVariation(0.2f).setRainfall(0.9f).setTemperature(0.9f).setWaterColor(14745518));
 
-		registerBiome(biomeId, "DeepSwamp", this);
+        this.setRegistryName(new ResourceLocation("advancedrocketry:DeepSwamp"));
 		
 		this.decorator.treesPerChunk = 10;
         this.decorator.flowersPerChunk = 1;

--- a/src/main/java/zmaster587/advancedRocketry/world/biome/BiomeGenHotDryRock.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/biome/BiomeGenHotDryRock.java
@@ -1,5 +1,6 @@
 package zmaster587.advancedRocketry.world.biome;
 
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.biome.Biome;
 import zmaster587.advancedRocketry.api.AdvancedRocketryBlocks;
 
@@ -8,11 +9,10 @@ public class BiomeGenHotDryRock extends Biome {
 	public BiomeGenHotDryRock(int biomeId, boolean register) {
 		super(new BiomeProperties("Hot Dry Rock").setRainDisabled().setBaseHeight(1f).setHeightVariation(0.01f).setRainfall(0).setTemperature(0.9f));
 		
-
-		registerBiome(biomeId, "Hot Dry Rock", this);
+        this.setRegistryName(new ResourceLocation("advancedrocketry:Hot Dry Rock"));
 		
 		//hot and stinks
-		this.decorator.generateLakes=false;
+		this.decorator.generateFalls=false;
 		this.decorator.flowersPerChunk=0;
 		this.decorator.grassPerChunk=0;
 		this.decorator.treesPerChunk=0;

--- a/src/main/java/zmaster587/advancedRocketry/world/biome/BiomeGenMarsh.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/biome/BiomeGenMarsh.java
@@ -3,6 +3,7 @@ package zmaster587.advancedRocketry.world.biome;
 import java.util.Random;
 
 import net.minecraft.init.Blocks;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.ChunkPrimer;
@@ -13,8 +14,8 @@ public class BiomeGenMarsh extends Biome {
 
 	public BiomeGenMarsh(int id, boolean b) {
 		super(new BiomeProperties("Marsh").setBaseHeight(-0.4f).setHeightVariation(0f));
-		
-		registerBiome(id, "Marsh", this);
+
+        this.setRegistryName(new ResourceLocation("advancedrocketry:Marsh"));
 		
 		this.decorator.clayPerChunk = 10;
 		this.decorator.flowersPerChunk = 0;

--- a/src/main/java/zmaster587/advancedRocketry/world/biome/BiomeGenMoon.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/biome/BiomeGenMoon.java
@@ -8,6 +8,7 @@ import zmaster587.advancedRocketry.AdvancedRocketry;
 import zmaster587.advancedRocketry.api.AdvancedRocketryBlocks;
 import net.minecraft.block.Block;
 import net.minecraft.entity.EnumCreatureType;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 
@@ -16,10 +17,11 @@ public class BiomeGenMoon extends Biome {
 	public BiomeGenMoon(int biomeId, boolean register) {
 		super(new BiomeProperties("Moon").setRainDisabled().setBaseHeight(1f).setHeightVariation(0.01f).setRainfall(0).setTemperature(0.3f));
 
-		registerBiome(biomeId, "Moon", this);
+		this.setRegistryName(new ResourceLocation("advancedrocketry:Moon"));
+//		registerBiome(biomeId, "Moon", this);
 		
 		//cold and dry
-		this.decorator.generateLakes=false;
+		this.decorator.generateFalls=false;
 		this.decorator.flowersPerChunk=0;
 		this.decorator.grassPerChunk=0;
 		this.decorator.treesPerChunk=0;

--- a/src/main/java/zmaster587/advancedRocketry/world/biome/BiomeGenOceanSpires.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/biome/BiomeGenOceanSpires.java
@@ -5,6 +5,7 @@ import java.util.Random;
 import zmaster587.advancedRocketry.world.decoration.MapGenInvertedPillar;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.ChunkPrimer;
@@ -18,8 +19,8 @@ public class BiomeGenOceanSpires extends Biome {
 	
 	public BiomeGenOceanSpires(int id, boolean register) {
 		super(new BiomeProperties("OceanSpires").setBaseHeight(-0.5f).setHeightVariation(0f));
-		
-		registerBiome(id, "OceanSpires", this);
+
+        this.setRegistryName(new ResourceLocation("advancedrocketry:OceanSpires"));
 		
 		this.decorator.clayPerChunk = 0;
 		this.decorator.flowersPerChunk = 0;

--- a/src/main/java/zmaster587/advancedRocketry/world/biome/BiomeGenSpace.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/biome/BiomeGenSpace.java
@@ -5,17 +5,17 @@ import java.util.List;
 
 import net.minecraft.entity.EnumCreatureType;
 import net.minecraft.init.Blocks;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.biome.Biome;
 
 public class BiomeGenSpace extends Biome {
 	public BiomeGenSpace(int biomeId, boolean register) {
 		super(new BiomeProperties("Space").setRainDisabled().setBaseHeight(-2f).setHeightVariation(0f).setTemperature(1f));
 		
-
-		registerBiome(biomeId, "Space", this);
+        this.setRegistryName(new ResourceLocation("advancedrocketry:Space"));
 		
 		//cold and dry
-		this.decorator.generateLakes=false;
+		this.decorator.generateFalls=false;
 		this.decorator.flowersPerChunk=0;
 		this.decorator.grassPerChunk=0;
 		this.decorator.treesPerChunk=0;

--- a/src/main/java/zmaster587/advancedRocketry/world/biome/BiomeGenStormland.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/biome/BiomeGenStormland.java
@@ -7,6 +7,7 @@ import zmaster587.advancedRocketry.world.gen.WorldGenCharredTree;
 import zmaster587.advancedRocketry.world.gen.WorldGenElectricMushroom;
 import net.minecraft.block.BlockFlower;
 import net.minecraft.entity.monster.EntityCreeper;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
@@ -21,12 +22,12 @@ public class BiomeGenStormland extends Biome {
 	public BiomeGenStormland(int biomeId, boolean register) {
 		super(new BiomeProperties("Stormland").setBaseHeight(1f).setHeightVariation(0.1f).setRainfall(0.9f).setTemperature(0.9f));
 		
-		registerBiome(biomeId, "Stormland", this);
+        this.setRegistryName(new ResourceLocation("advancedrocketry:Stormland"));
 		
 		spawnableMonsterList.clear();
 		this.spawnableMonsterList.add(new Biome.SpawnListEntry(EntityCreeper.class, 5, 1, 1));
 		this.spawnableCreatureList.clear();
-		this.decorator.generateLakes=false;
+		this.decorator.generateFalls=false;
 		this.decorator.flowersPerChunk=0;
 		this.decorator.grassPerChunk=0;
 		this.decorator.treesPerChunk=6;

--- a/src/main/java/zmaster587/advancedRocketry/world/biome/BiomeGenWatermelon.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/biome/BiomeGenWatermelon.java
@@ -16,7 +16,7 @@ public class BiomeGenWatermelon extends Biome {
 		
 		//cold and dry
 		
-		this.decorator.generateLakes=false;
+		this.decorator.generateFalls=false;
 		this.decorator.flowersPerChunk=0;
 		this.decorator.grassPerChunk=0;
 		this.decorator.treesPerChunk=0;

--- a/src/main/java/zmaster587/advancedRocketry/world/gen/WorldGenElectricMushroom.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/gen/WorldGenElectricMushroom.java
@@ -28,7 +28,7 @@ public class WorldGenElectricMushroom extends WorldGenerator {
         {
             BlockPos blockpos = position.add(rand.nextInt(8) - rand.nextInt(8), rand.nextInt(4) - rand.nextInt(4), rand.nextInt(8) - rand.nextInt(8));
 
-            if (worldIn.isAirBlock(blockpos) && (!worldIn.provider.hasNoSky() || blockpos.getY() < 255) && ((BlockElectricMushroom)this.state.getBlock()).canBlockStay(worldIn, blockpos, this.state))
+            if (worldIn.isAirBlock(blockpos) && (worldIn.provider.isSurfaceWorld() || blockpos.getY() < 255) && ((BlockElectricMushroom)this.state.getBlock()).canBlockStay(worldIn, blockpos, this.state))
             {
                 worldIn.setBlockState(blockpos, state, 2);
             }

--- a/src/main/java/zmaster587/advancedRocketry/world/ore/CustomizableOreGen.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/ore/CustomizableOreGen.java
@@ -2,14 +2,14 @@ package zmaster587.advancedRocketry.world.ore;
 
 import java.util.Random;
 
-import zmaster587.advancedRocketry.util.OreGenProperties;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraft.world.chunk.IChunkGenerator;
 import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraft.world.gen.IChunkGenerator;
 import net.minecraft.world.gen.feature.WorldGenMinable;
 import net.minecraftforge.fml.common.IWorldGenerator;
+import zmaster587.advancedRocketry.util.OreGenProperties;
 
 public class CustomizableOreGen implements IWorldGenerator {
 

--- a/src/main/java/zmaster587/advancedRocketry/world/ore/OreGenerator.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/ore/OreGenerator.java
@@ -2,20 +2,12 @@ package zmaster587.advancedRocketry.world.ore;
 
 import java.util.Random;
 
-import zmaster587.advancedRocketry.api.Configuration;
-import zmaster587.advancedRocketry.dimension.DimensionManager;
-import zmaster587.advancedRocketry.dimension.DimensionProperties;
-import zmaster587.advancedRocketry.world.provider.WorldProviderPlanet;
-import zmaster587.libVulpes.api.material.AllowedProducts;
-import zmaster587.libVulpes.api.material.Material;
-import zmaster587.libVulpes.api.material.MaterialRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.init.Blocks;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraft.world.chunk.IChunkGenerator;
 import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraft.world.gen.IChunkGenerator;
 import net.minecraft.world.gen.feature.WorldGenMinable;
 import net.minecraft.world.gen.feature.WorldGenerator;
 import net.minecraftforge.common.MinecraftForge;
@@ -23,6 +15,13 @@ import net.minecraftforge.event.terraingen.OreGenEvent;
 import net.minecraftforge.event.terraingen.OreGenEvent.GenerateMinable.EventType;
 import net.minecraftforge.fml.common.IWorldGenerator;
 import net.minecraftforge.fml.common.eventhandler.Event.Result;
+import zmaster587.advancedRocketry.api.Configuration;
+import zmaster587.advancedRocketry.dimension.DimensionManager;
+import zmaster587.advancedRocketry.dimension.DimensionProperties;
+import zmaster587.advancedRocketry.world.provider.WorldProviderPlanet;
+import zmaster587.libVulpes.api.material.AllowedProducts;
+import zmaster587.libVulpes.api.material.Material;
+import zmaster587.libVulpes.api.material.MaterialRegistry;
 
 public class OreGenerator extends WorldGenerator implements IWorldGenerator {
 

--- a/src/main/java/zmaster587/advancedRocketry/world/provider/WorldProviderPlanet.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/provider/WorldProviderPlanet.java
@@ -5,6 +5,20 @@ import java.util.Set;
 
 import org.apache.commons.lang3.ArrayUtils;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.DimensionType;
+import net.minecraft.world.WorldProvider;
+import net.minecraft.world.biome.BiomeProvider;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.gen.IChunkGenerator;
+import net.minecraftforge.client.IRenderHandler;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import zmaster587.advancedRocketry.AdvancedRocketry;
 import zmaster587.advancedRocketry.api.AdvancedRocketryBlocks;
 import zmaster587.advancedRocketry.api.Configuration;
@@ -16,20 +30,6 @@ import zmaster587.advancedRocketry.dimension.DimensionManager;
 import zmaster587.advancedRocketry.dimension.DimensionProperties;
 import zmaster587.advancedRocketry.world.ChunkManagerPlanet;
 import zmaster587.advancedRocketry.world.ChunkProviderPlanet;
-import net.minecraft.client.Minecraft;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.Vec3d;
-import net.minecraft.world.DimensionType;
-import net.minecraft.world.WorldProvider;
-import net.minecraft.world.biome.BiomeProvider;
-import net.minecraft.world.chunk.Chunk;
-import net.minecraft.world.chunk.IChunkGenerator;
-import net.minecraftforge.client.IRenderHandler;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class WorldProviderPlanet extends WorldProvider implements IPlanetaryProvider {
 	public BiomeProvider chunkMgrTerraformed;
@@ -227,7 +227,7 @@ public class WorldProviderPlanet extends WorldProvider implements IPlanetaryProv
 			return super.getSkyColor(cameraEntity, partialTicks);
 		else {
 			Vec3d skyColorVec = super.getSkyColor(cameraEntity, partialTicks);
-			return new Vec3d(vec[0] * skyColorVec.xCoord, vec[1] * skyColorVec.yCoord, vec[2] * skyColorVec.zCoord) ;
+			return new Vec3d(vec[0] * skyColorVec.x, vec[1] * skyColorVec.y, vec[2] * skyColorVec.z) ;
 		}
 	}
 
@@ -239,7 +239,7 @@ public class WorldProviderPlanet extends WorldProvider implements IPlanetaryProv
 		//float multiplier = getAtmosphereDensityFromHeight(Minecraft.getMinecraft().renderViewEntity.posY);
 
 		float[] vec = getDimensionProperties(new BlockPos((int)Minecraft.getMinecraft().player.posX, 0, (int)Minecraft.getMinecraft().player.posZ)).fogColor;
-		return new Vec3d(vec[0] * superVec.xCoord, vec[1] * superVec.yCoord, vec[2] * superVec.zCoord);
+		return new Vec3d(vec[0] * superVec.x, vec[1] * superVec.y, vec[2] * superVec.z);
 	}
 
 	@Override

--- a/src/main/java/zmaster587/advancedRocketry/world/provider/WorldProviderSpace.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/provider/WorldProviderSpace.java
@@ -1,5 +1,11 @@
 package zmaster587.advancedRocketry.world.provider;
 
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.biome.BiomeProviderSingle;
+import net.minecraft.world.gen.IChunkGenerator;
+import net.minecraftforge.client.IRenderHandler;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import zmaster587.advancedRocketry.AdvancedRocketry;
 import zmaster587.advancedRocketry.api.AdvancedRocketryBiomes;
 import zmaster587.advancedRocketry.api.stations.ISpaceObject;
@@ -7,14 +13,7 @@ import zmaster587.advancedRocketry.client.render.planet.RenderSpaceSky;
 import zmaster587.advancedRocketry.dimension.DimensionManager;
 import zmaster587.advancedRocketry.dimension.DimensionProperties;
 import zmaster587.advancedRocketry.stations.SpaceObjectManager;
-import zmaster587.advancedRocketry.world.ChunkManagerPlanet;
 import zmaster587.advancedRocketry.world.ChunkProviderSpace;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.biome.BiomeProviderSingle;
-import net.minecraft.world.chunk.IChunkGenerator;
-import net.minecraftforge.client.IRenderHandler;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class WorldProviderSpace extends WorldProviderPlanet {
 	private IRenderHandler skyRender;

--- a/src/main/java/zmaster587/advancedRocketry/world/type/WorldTypePlanetGen.java
+++ b/src/main/java/zmaster587/advancedRocketry/world/type/WorldTypePlanetGen.java
@@ -1,17 +1,14 @@
 package zmaster587.advancedRocketry.world.type;
 
-import zmaster587.advancedRocketry.world.ChunkProviderPlanet;
-import zmaster587.advancedRocketry.world.GenLayerBiomePlanet;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldType;
 import net.minecraft.world.biome.BiomeProvider;
-import net.minecraft.world.chunk.IChunkGenerator;
-import net.minecraft.world.chunk.IChunkProvider;
-import net.minecraft.world.gen.ChunkProviderSettings;
+import net.minecraft.world.gen.ChunkGeneratorSettings;
+import net.minecraft.world.gen.IChunkGenerator;
 import net.minecraft.world.gen.layer.GenLayer;
-import net.minecraft.world.gen.layer.GenLayerEdge;
-import net.minecraft.world.gen.layer.GenLayerEdge.Mode;
 import net.minecraft.world.gen.layer.GenLayerZoom;
+import zmaster587.advancedRocketry.world.ChunkProviderPlanet;
+import zmaster587.advancedRocketry.world.GenLayerBiomePlanet;
 
 public class WorldTypePlanetGen extends WorldType {
 
@@ -45,7 +42,7 @@ public class WorldTypePlanetGen extends WorldType {
 	 * @return A GenLayer that will return ints representing the Biomes to be generated, see GenLayerBiome
 	 */
 	@Override
-	public GenLayer getBiomeLayer(long worldSeed, GenLayer parentLayer, ChunkProviderSettings chunkProviderSettings)
+	public GenLayer getBiomeLayer(long worldSeed, GenLayer parentLayer, ChunkGeneratorSettings chunkProviderSettings)
 	{
 		//return super.getBiomeLayer(worldSeed, parentLayer);
 		GenLayer ret = new GenLayerBiomePlanet(200L, parentLayer, this);

--- a/src/main/resources/META-INF/accessTransformer.cfg
+++ b/src/main/resources/META-INF/accessTransformer.cfg
@@ -1,13 +1,1 @@
 public net.minecraft.entity.Entity *
-#public net.minecraft.entity.Entity field_70134_J
-#updateFallState
-public net.minecraft.entity.Entity func_70064_a(DZ)V
-#canTriggerWalking
-public net.minecraft.entity.Entity func_70041_e_()Z
-public net.minecraft.entity.Entity func_145780_a(IIILnet/minecraft/block/Block;)V
-public net.minecraft.entity.Entity func_145780_a func_145775_I()V
-#dealFireDamage
-public net.minecraft.entity.Entity func_70081_e(I)V
-
-#isJumping
-public net.minecraft.entity.EntityLivingBase field_70703_bu


### PR DESCRIPTION
Here is the result of my inital attempt at a 1.12 port.  

I am using the mappings from 1.12, so a few fields have changed names, I also did this in my general 1.12 build enviroment, so was built against a version for 1.12.1.

Major organizational changes:

Item, Block and Biome registration has moved to their specific events.
Recipe registration was changed to using an actual registry in 1.12.

Things I have tested as working so far:

I built a rocket, flew it to moon, made pressurized hut on moon.
said hut I put a voltorb in, and before the oxygen was setup right, voltorb suffocated, once I had oxygen in the vent, he powered the vent and stopped suffocating.
I also tested cancelling AtmosphereTickEvent for a mob to make it not suffocate on moon (clefairy) and it didn't suffocate as planned.

Currently not functioning: 

Anything ASM related.  the ASM for item gravity works in development environment, but doesn't seem to do so for the compiled one, so I am probably doing something wrong there (I have no experience with core mod stuff)

Advancements/Achievements.  I haven't got around to adding in the advancement triggers needed, or making the advancement jsons for the achievements that were originally had.  This won't be particularly complicated to do, mostly requires making a bunch of json files.

Some things are missing textures, though I think that was also the case in the 1.11.2 branch.

Attached is a zip containing the mods, I tested them on 1.12.2 forge version 2493, they were compiled against 14.22.1.2485 for 1.12.1

[mods.zip](https://github.com/zmaster587/AdvancedRocketry/files/1350987/mods.zip)