### PR TITLE
Fixes asteroid missions not working in 1.11

### DIFF
--- a/src/main/java/zmaster587/advancedRocketry/mission/MissionOreMining.java
+++ b/src/main/java/zmaster587/advancedRocketry/mission/MissionOreMining.java
@@ -81,7 +81,7 @@ public class MissionOreMining extends MissionResourceCollection {
 
 
 							for(int offset = 0; offset < tile.getSizeInventory() && g < stacks.length; offset++, g++) {
-								if(tile.getStackInSlot(offset) == null)
+								if(tile.getStackInSlot(offset).isEmpty())
 									tile.setInventorySlotContents(offset, stacks[g]);
 							}
 						}


### PR DESCRIPTION
This also needs to be merged into the 1.12 branch, as it is also broken there (that is where I noticed the asteroid mining not working, but I put the PR here instead)