### PR TITLE
Rethrow exceptions instead of calling System.exit

### DIFF
--- a/src/main/java/zmaster587/advancedRocketry/client/render/entity/RenderElevatorCapsule.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/entity/RenderElevatorCapsule.java
@@ -36,9 +36,7 @@ public class RenderElevatorCapsule extends Render<EntityElevatorCapsule> impleme
 		try {
 			sphere = new WavefrontObject(new ResourceLocation("advancedrocketry:models/spaceElevator.obj"));
 		} catch(ModelFormatException e) {
-			sphere = null;
-			e.printStackTrace();
-			System.exit(0);
+			throw new RuntimeException(e);
 		}
 	}
 

--- a/src/main/java/zmaster587/advancedRocketry/client/render/entity/RenderPlanetUIEntity.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/entity/RenderPlanetUIEntity.java
@@ -32,9 +32,7 @@ public class RenderPlanetUIEntity extends Render<EntityUIPlanet> implements IRen
 		try {
 			sphere = new WavefrontObject(new ResourceLocation("advancedrocketry:models/atmosphere.obj"));
 		} catch(ModelFormatException e) {
-			sphere = null;
-			e.printStackTrace();
-			System.exit(0);
+			throw new RuntimeException(e);
 		}
 	}
 


### PR DESCRIPTION
With Forge, you're never supposed to call System.exit. It won't work anyway
(they disable it), and even having it in your code makes a big warning in the
log. Change this to the right way of dealing with a checked exception you
can't just propagate: wrap it in an unchecked exception.