### PR TITLE
Fix pressure tanks returning wrong capability

### DIFF
--- a/src/main/java/zmaster587/advancedRocketry/capability/TankCapabilityItemStack.java
+++ b/src/main/java/zmaster587/advancedRocketry/capability/TankCapabilityItemStack.java
@@ -24,6 +24,9 @@ public class TankCapabilityItemStack implements ICapabilityProvider {
 
 	@Override
 	public <T> T getCapability(Capability<T> capability, EnumFacing facing) {
-		return (T) fluidHandler;
+		if (hasCapability(capability, facing)) {
+			return CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY.cast(fluidHandler);
+		}
+		return null;
 	}
 }


### PR DESCRIPTION
Fair warning: this was written on github, so you might want to double check the syntax.

This fixes crashes like [this one](https://pastebin.com/NTsgib8A) when getCapability is queried with a capability other than IFluidHandlerItem.