### PR TITLE
Fix for custom gas collection at Gas Giants

### DIFF
--- a/src/main/java/zmaster587/advancedRocketry/entity/EntityStationDeployedRocket.java
+++ b/src/main/java/zmaster587/advancedRocketry/entity/EntityStationDeployedRocket.java
@@ -355,9 +355,9 @@ public class EntityStationDeployedRocket extends EntityRocket {
 		}
 		//one intake with a 1 bucket tank should take 100 seconds
 		float intakePower = (Integer)stats.getStatTag("intakePower");
-		MissionGasCollection miningMission = new MissionGasCollection(intakePower == 0 ? 360 : (long)(2*((int)stats.getStatTag("liquidCapacity")/intakePower)), this, connectedInfrastructure, AtmosphereRegister.getInstance().getHarvestableGasses().get(gasId));
-		DimensionProperties properties = (DimensionProperties)spaceObj.getProperties().getParentProperties();
 
+		DimensionProperties properties = (DimensionProperties)spaceObj.getProperties().getParentProperties();
+		MissionGasCollection miningMission = new MissionGasCollection(intakePower == 0 ? 360 : (long)(2*((int)stats.getStatTag("liquidCapacity")/intakePower)), this, connectedInfrastructure, properties.getHarvestableGasses().get(gasId));
 
 		miningMission.setDimensionId(properties.getId());
 		properties.addSatallite(miningMission);


### PR DESCRIPTION
Issue appears to have been caused by the new miningMission being created from the full registry of harvestable gases instead of the list of harvestable gases from that dimension only.

Adjusted the miningMission creation to pull the list from the Dimension Properties as opposed to the full registry.  Should resolve issue #1259.