### PR TITLE
Correct the null check to fix #709

### DIFF
--- a/src/main/java/zmaster587/advancedRocketry/entity/EntityRocket.java
+++ b/src/main/java/zmaster587/advancedRocketry/entity/EntityRocket.java
@@ -946,7 +946,7 @@ public class EntityRocket extends EntityRocketBase implements INetworkEntity, IM
 				else
 					world2 = net.minecraftforge.common.DimensionManager.getWorld(destinationId);
 				
-				if(world != null)
+				if(world2 != null)
 					properties.addSatallite(satellite, world2);
 				tile.setInventorySlotContents(0, ItemStack.EMPTY);
 			}


### PR DESCRIPTION
So, today I've run into the bug #709. The null check should be on `world2` since you pass it to `addSatallite` where the exception occurs.