### PR TITLE
1.12 patches

### DIFF
--- a/src/main/java/zmaster587/advancedRocketry/api/StatsRocket.java
+++ b/src/main/java/zmaster587/advancedRocketry/api/StatsRocket.java
@@ -42,6 +42,8 @@ public class StatsRocket {
 
 	private static final String TAGNAME = "rocketStats";
 	private HashMap<String, Object> statTags;
+	
+	private static final int INVALID_SEAT = Integer.MIN_VALUE;
 
 	public StatsRocket() {
 		thrust = 0;
@@ -49,7 +51,7 @@ public class StatsRocket {
 		fuelLiquid = 0;
 		drillingPower = 0f;
 		pilotSeatPos = new HashedBlockPosition(0,0,0);
-		pilotSeatPos.x = -1;
+		pilotSeatPos.x = INVALID_SEAT;
 		engineLoc = new ArrayList<Vector3F<Float>>();
 		statTags = new HashMap<String, Object>();
 	}
@@ -312,7 +314,7 @@ public class StatsRocket {
 	 * @return true if a seat exists on this stat
 	 */
 	public boolean hasSeat() {
-		return pilotSeatPos.x != -1;
+		return pilotSeatPos.x != INVALID_SEAT;
 	}
 
 	/**
@@ -330,7 +332,7 @@ public class StatsRocket {
 		}
 
 		fuelLiquid = 0;
-		pilotSeatPos.x = -1;
+		pilotSeatPos.x = INVALID_SEAT;
 		clearEngineLocations();
 		passengerSeats.clear();
 		statTags.clear();

--- a/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RenderBlackHoleEnergy.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/multiblocks/RenderBlackHoleEnergy.java
@@ -47,7 +47,7 @@ public class RenderBlackHoleEnergy extends TileEntitySpecialRenderer {
 		EnumFacing front = RotatableBlock.getFront(tile.getWorld().getBlockState(tile.getPos())); //tile.getWorldObj().getBlockMetadata(tile.xCoord, tile.yCoord, tile.zCoord));
 		GL11.glTranslated(x + .5, y + .5, z + .5);
 
-		GL11.glRotatef((front.getFrontOffsetZ() == 1 ? 180 : 0) + front.getFrontOffsetX()*90f, 0, 1, 0);
+		GL11.glRotatef((front.getFrontOffsetZ() == 1 ? 180 : 0) - front.getFrontOffsetX()*90f, 0, 1, 0);
 		
 		bindTexture(texture);
 		

--- a/src/main/java/zmaster587/advancedRocketry/client/render/planet/RenderPlanetarySky.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/planet/RenderPlanetarySky.java
@@ -912,6 +912,9 @@ public class RenderPlanetarySky extends IRenderHandler {
 				GL11.glPopMatrix();
 			}
 
+			GlStateManager.depthMask(true);
+			GL11.glClear(GL11.GL_DEPTH_BUFFER_BIT);
+			GlStateManager.depthMask(false);
 
 		}
 		else {

--- a/src/main/java/zmaster587/advancedRocketry/integration/jei/chemicalReactor/ChemicalReactorRecipeMaker.java
+++ b/src/main/java/zmaster587/advancedRocketry/integration/jei/chemicalReactor/ChemicalReactorRecipeMaker.java
@@ -18,25 +18,6 @@ public class ChemicalReactorRecipeMaker {
 			list.add(new ChemicalReactorlWrapper(rec));
 		}
 		
-		List<ItemStack> input = new LinkedList<ItemStack>();
-		input.add(new ItemStack(AdvancedRocketryItems.itemBucketHydrogen));
-		
-		
-		
-		List<List<ItemStack>> finalInput  = new LinkedList<List<ItemStack>>();
-		finalInput.add(input);
-		input = new LinkedList<ItemStack>();
-		input.add(new ItemStack(AdvancedRocketryItems.itemBucketOxygen));
-		finalInput.add(input);
-		
-		List<ItemStack> output = new LinkedList<ItemStack>();
-		output.add(new ItemStack(AdvancedRocketryItems.itemBucketRocketFuel));
-		
-		
-		IRecipe rocketFuel = new RecipesMachine.Recipe(output, finalInput, 0, 0, null);
-		
-		list.add(new ChemicalReactorlWrapper(rocketFuel));
-		
 		return list;
 	}
 	

--- a/src/main/java/zmaster587/advancedRocketry/integration/jei/chemicalReactor/ChemicalReactorRecipeMaker.java
+++ b/src/main/java/zmaster587/advancedRocketry/integration/jei/chemicalReactor/ChemicalReactorRecipeMaker.java
@@ -1,8 +1,6 @@
 package zmaster587.advancedRocketry.integration.jei.chemicalReactor;
 
 import mezz.jei.api.IJeiHelpers;
-import net.minecraft.item.ItemStack;
-import zmaster587.advancedRocketry.api.AdvancedRocketryItems;
 import zmaster587.libVulpes.interfaces.IRecipe;
 import zmaster587.libVulpes.recipe.RecipesMachine;
 

--- a/src/main/java/zmaster587/advancedRocketry/integration/jei/electrolyser/ElectrolyzerRecipeMaker.java
+++ b/src/main/java/zmaster587/advancedRocketry/integration/jei/electrolyser/ElectrolyzerRecipeMaker.java
@@ -19,19 +19,6 @@ public class ElectrolyzerRecipeMaker {
 			list.add(new ElectrolyzerWrapper(rec));
 		}
 		
-		List<ItemStack> output = new LinkedList<ItemStack>();
-		output.add(new ItemStack(AdvancedRocketryItems.itemBucketHydrogen));
-		output.add(new ItemStack(AdvancedRocketryItems.itemBucketOxygen));
-		
-		List<ItemStack> input = new LinkedList<ItemStack>();
-		List<List<ItemStack>> finalInput  = new LinkedList<List<ItemStack>>();
-		input.add(new ItemStack(Items.WATER_BUCKET));
-		finalInput.add(input);
-		
-		IRecipe waterElectro = new RecipesMachine.Recipe(output, finalInput, 0, 0, null);
-		
-		list.add(new ElectrolyzerWrapper(waterElectro));
-		
 		return list;
 	}
 	

--- a/src/main/java/zmaster587/advancedRocketry/integration/jei/electrolyser/ElectrolyzerRecipeMaker.java
+++ b/src/main/java/zmaster587/advancedRocketry/integration/jei/electrolyser/ElectrolyzerRecipeMaker.java
@@ -1,9 +1,6 @@
 package zmaster587.advancedRocketry.integration.jei.electrolyser;
 
 import mezz.jei.api.IJeiHelpers;
-import net.minecraft.init.Items;
-import net.minecraft.item.ItemStack;
-import zmaster587.advancedRocketry.api.AdvancedRocketryItems;
 import zmaster587.libVulpes.interfaces.IRecipe;
 import zmaster587.libVulpes.recipe.RecipesMachine;
 


### PR DESCRIPTION
Fixed rocket seats at x=-1 being considered invalid
Fixed black hole generator model being flipped when facing +x and -x
Fixed black holes being displayed through distant terrain
Fixed 2 recipes in electrolyser and chemical reactor always being present, even when removed from the recipe file.