### PR TITLE
Update en_US.lang

### DIFF
--- a/src/main/resources/assets/advancedrocketry/lang/en_US.lang
+++ b/src/main/resources/assets/advancedrocketry/lang/en_US.lang
@@ -2,8 +2,8 @@ itemGroup.advancedRocketry=Advanced Rocketry
 itemGroup.advancedRocketryOres=Advanced Rocketry Ores
 
 death.attack.Vacuum=You have been depressurized
-death.attack.Vacuum.player=Was depressurized
-entity.advancedRocketry.rocket.name=Rocket
+death.attack.Vacuum.player=was depressurized
+entity.rocket.name=Rocket
 
 tile.landingPad.name=Landing Pad
 tile.seat.name=Seat


### PR DESCRIPTION
Fixed a casing issue as well as an incorrect naming causing Rockets to show up as "entity.rocket.name" instead of the correct "Rocket"