### PR TITLE
Fix rocket names

### DIFF
--- a/src/main/resources/assets/advancedrocketry/lang/de_DE.lang
+++ b/src/main/resources/assets/advancedrocketry/lang/de_DE.lang
@@ -4,6 +4,7 @@ itemGroup.advancedRocketryOres=Advanced Rocketry Erze
 death.attack.Vacuum=Du standest nicht mehr unter Druck 
 death.attack.Vacuum.player=Stand nicht mehr unter Druck
 entity.advancedRocketry.rocket.name=Rakete
+entity.rocket.name=Rakete
 
 tile.rocketAssembler.name=Raketenmonteur
 tile.turf.name=Monderde

--- a/src/main/resources/assets/advancedrocketry/lang/en_US.lang
+++ b/src/main/resources/assets/advancedrocketry/lang/en_US.lang
@@ -4,6 +4,7 @@ itemGroup.advancedRocketryOres=Advanced Rocketry Ores
 death.attack.Vacuum=You have been depressurized
 death.attack.Vacuum.player=Was depressurized
 entity.advancedRocketry.rocket.name=Rocket
+entity.rocket.name=Rocket
 
 tile.landingPad.name=Landing Pad
 tile.seat.name=Seat

--- a/src/main/resources/assets/advancedrocketry/lang/es_ES.lang
+++ b/src/main/resources/assets/advancedrocketry/lang/es_ES.lang
@@ -2,6 +2,7 @@ itemGroup.advancedRocketry=Advanced Rocketry
 itemGroup.advancedRocketryOres=Menas de Advanced Rocketry
 
 entity.advancedRocketry.rocket.name=Cohete
+entity.rocket.name=Cohete
 
 tile.seat.name=Asiento
 tile.pad.name=Plataforma de lanzamiento

--- a/src/main/resources/assets/advancedrocketry/lang/fr_FR.lang
+++ b/src/main/resources/assets/advancedrocketry/lang/fr_FR.lang
@@ -4,6 +4,7 @@ itemGroup.advancedRocketryOres=Minerai d'Advanced Rocketry
 death.attack.Vacuum=Accident de décompression
 death.attack.Vacuum.player=Est mort dans un accident de décompression
 entity.advancedRocketry.rocket.name=Fusée
+entity.rocket.name=Fusée
 
 tile.landingPad.name=Plate-forme d'atterrissage 
 tile.seat.name=Siège

--- a/src/main/resources/assets/advancedrocketry/lang/pt_br.lang
+++ b/src/main/resources/assets/advancedrocketry/lang/pt_br.lang
@@ -4,6 +4,7 @@ itemGroup.advancedRocketryOres=Advanced Rocketry Ores
 death.attack.Vacuum=You have been depressurized
 death.attack.Vacuum.player=Was depressurized
 entity.advancedRocketry.rocket.name=Rocket
+entity.rocket.name=Rocket
 
 tile.seat.name=Seat
 tile.pad.name=Launch Pad

--- a/src/main/resources/assets/advancedrocketry/lang/ru_RU.lang
+++ b/src/main/resources/assets/advancedrocketry/lang/ru_RU.lang
@@ -4,6 +4,7 @@ itemGroup.advancedRocketryOres=Руды Advanced Rocketry
 death.attack.Vacuum=Вас разгерметизировало
 death.attack.Vacuum.player=был разгерметизирован
 entity.advancedRocketry.rocket.name=Ракета
+entity.rocket.name=Ракета
 
 tile.landingPad.name=Посадочная площадка
 tile.seat.name=Сиденье

--- a/src/main/resources/assets/advancedrocketry/lang/ua_UA.lang
+++ b/src/main/resources/assets/advancedrocketry/lang/ua_UA.lang
@@ -2,6 +2,7 @@ itemGroup.advancedRocketry = Advanced Rocketry
 itemGroup.advancedRocketryOres=Руди Advanced Rocketry
  
 entity.advancedRocketry.rocket.name = Ракета
+entity.rocket.name = Ракета
  
 tile.seat.name=Сидіння
 tile.pad.name=Стартовий майданчик

--- a/src/main/resources/assets/advancedrocketry/lang/zh_CN.lang
+++ b/src/main/resources/assets/advancedrocketry/lang/zh_CN.lang
@@ -4,6 +4,7 @@ itemGroup.advancedRocketryOres=高级火箭矿物
 death.attack.Vacuum=你被减压死了
 death.attack.Vacuum.player=减压死了
 entity.advancedRocketry.rocket.name=火箭
+entity.rocket.name=火箭
 
 tile.seat.name=座位
 tile.pad.name=发射台


### PR DESCRIPTION
No more entity.rocket.name showing in OneProbe, /say commands and more. I left the `entity.advancedRocketry.rocket.name` in, just to be save.