### PR TITLE
Focuses the planet selector on the player's current solar system if possible

### DIFF
--- a/src/main/java/zmaster587/advancedRocketry/tile/multiblock/TilePlanetSelector.java
+++ b/src/main/java/zmaster587/advancedRocketry/tile/multiblock/TilePlanetSelector.java
@@ -70,7 +70,8 @@ public class TilePlanetSelector extends TilePointer implements ISelectionNotify,
 
 		List<ModuleBase> modules = new LinkedList<ModuleBase>();
 
-		container = new ModulePlanetSelector(0, TextureResources.starryBG, this, true);
+                DimensionProperties props = DimensionManager.getEffectiveDimId(player.world, player.getPosition());
+		container = new ModulePlanetSelector((props != null ? props.getStarId() : 0), TextureResources.starryBG, this, true);
 		container.setOffset(1000, 1000);
 		modules.add(container);
 


### PR DESCRIPTION
Small thing, but we've found it helpful. Feel free to disregard.