### PR TITLE
Use oredictionary instead of Vanilla blocks

### DIFF
--- a/src/main/java/zmaster587/advancedRocketry/tile/multiblock/TileAstrobodyDataProcessor.java
+++ b/src/main/java/zmaster587/advancedRocketry/tile/multiblock/TileAstrobodyDataProcessor.java
@@ -40,8 +40,8 @@ import java.util.Random;
 public class TileAstrobodyDataProcessor extends TileMultiPowerConsumer implements IModularInventory, IInventory {
 
 	private static final Object[][][] structure = new Object[][][]{
-		{{Blocks.STONE_SLAB, 'c', Blocks.STONE_SLAB},
-			{Blocks.STONE_SLAB, Blocks.STONE_SLAB, Blocks.STONE_SLAB}},
+		{{"slab", 'c', "slab"},
+			{"slab", "slab", "slab"}},
 
 			{{'P','I', 'O'},
 				{'D','D','D'}}

--- a/src/main/java/zmaster587/advancedRocketry/tile/multiblock/TileObservatory.java
+++ b/src/main/java/zmaster587/advancedRocketry/tile/multiblock/TileObservatory.java
@@ -51,33 +51,33 @@ public class TileObservatory extends TileMultiPowerConsumer implements IModularI
 	private static final Object[][][] structure = new Object[][][]{
 
 		{	{null, null, null, null, null}, 
-			{null, Blocks.STONE, lens, Blocks.STONE, null},
-			{null, Blocks.STONE, Blocks.STONE, Blocks.STONE, null},
-			{null, Blocks.STONE, Blocks.STONE, Blocks.STONE, null},
+			{null, "stone", lens, "stone", null},
+			{null, "stone", "stone", "stone", null},
+			{null, "stone", "stone", "stone", null},
 			{null, null, null, null, null}},
 
 			{	{null,null,null,null,null}, 
-				{null, Blocks.STONE, Blocks.STONE, Blocks.STONE, null},
-				{null, Blocks.STONE, lens, Blocks.STONE, null},
-				{null, Blocks.STONE, Blocks.STONE, Blocks.STONE, null},
+				{null, "stone", "stone", "stone", null},
+				{null, "stone", lens, "stone", null},
+				{null, "stone", "stone", "stone", null},
 				{null,null,null,null,null}},
 
-				{	{null, Blocks.STONE, Blocks.STONE, Blocks.STONE, null}, 
-					{Blocks.STONE, Blocks.AIR, Blocks.AIR, Blocks.AIR, Blocks.STONE},
-					{Blocks.STONE, Blocks.AIR, Blocks.AIR, Blocks.AIR, Blocks.STONE},
-					{Blocks.STONE, Blocks.AIR, lens, Blocks.AIR, Blocks.STONE},
-					{null, Blocks.STONE, Blocks.STONE, Blocks.STONE, null}},
+				{	{null, "stone", "stone", "stone", null},
+					{"stone", Blocks.AIR, Blocks.AIR, Blocks.AIR, "stone"},
+					{"stone", Blocks.AIR, Blocks.AIR, Blocks.AIR, "stone"},
+					{"stone", Blocks.AIR, lens, Blocks.AIR, "stone"},
+					{null, "stone", "stone", "stone", null}},
 
 					{	{ null,'*', 'c', '*',null}, 
-						{'*',Blocks.STONE, Blocks.STONE, Blocks.STONE,'*'},
-						{'*',Blocks.STONE, Blocks.STONE, Blocks.STONE,'*'},
-						{'*',Blocks.STONE, Blocks.STONE, Blocks.STONE,'*'},
+						{'*',"stone", "stone", "stone",'*'},
+						{'*',"stone", "stone", "stone",'*'},
+						{'*',"stone", "stone", "stone",'*'},
 						{null,'*', '*', '*', null}},
 
 						{	{null,'*', '*', '*', null}, 
-							{'*',Blocks.STONE, Blocks.STONE, Blocks.STONE,'*'},
-							{'*',Blocks.STONE, LibVulpesBlocks.motors, Blocks.STONE,'*'},
-							{'*',Blocks.STONE, Blocks.STONE, Blocks.STONE,'*'},
+							{'*',"stone", "stone", "stone",'*'},
+							{'*',"stone", LibVulpesBlocks.motors, "stone",'*'},
+							{'*',"stone", "stone", "stone",'*'},
 							{null,'*', '*', '*',null}}};
 
 	final static int openTime = 100;


### PR DESCRIPTION
Supports Terrafirmacraft, which has no Vanilla stone. 2 of the multiblock structures had Blocks.Stone or Slab reference. Changed to oredict entries to support TFC.