### PR TITLE
Fix planetsize calculations and orbitalPhi calculations

### DIFF
--- a/src/main/java/zmaster587/advancedRocketry/client/render/planet/RenderAsteroidSky.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/planet/RenderAsteroidSky.java
@@ -644,7 +644,6 @@ public class RenderAsteroidSky extends IRenderHandler {
 		for(DimensionProperties moons : children) {
 			GL11.glPushMatrix();
 
-			moons.orbitalPhi = 10;
 			double rot = ((partialTicks*moons.orbitTheta + ((1-partialTicks)*moons.prevOrbitalTheta)) * 180F/Math.PI);
 
 			GL11.glRotatef((float)moons.orbitalPhi, 0f, 0f, 1f);

--- a/src/main/java/zmaster587/advancedRocketry/client/render/planet/RenderAsteroidSky.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/planet/RenderAsteroidSky.java
@@ -724,7 +724,7 @@ public class RenderAsteroidSky extends IRenderHandler {
 	}
 
 	protected void renderPlanet2(BufferBuilder buffer, ResourceLocation icon, int locationX, int locationY, double zLevel, float size, float alphaMultiplier, double shadowAngle, boolean hasAtmosphere, float[] skyColor, float[] ringColor, boolean gasGiant, boolean hasRing, float gravitationalMultiplier) {
-		renderPlanetPubHelper(buffer, icon, locationX, locationY, zLevel, 2f*size*gravitationalMultiplier, alphaMultiplier, shadowAngle, hasAtmosphere, skyColor, ringColor, gasGiant, hasRing);
+		renderPlanetPubHelper(buffer, icon, locationX, locationY, zLevel, size*gravitationalMultiplier, alphaMultiplier, shadowAngle, hasAtmosphere, skyColor, ringColor, gasGiant, hasRing);
 	}
 
 	protected void rotateAroundAxis() {

--- a/src/main/java/zmaster587/advancedRocketry/client/render/planet/RenderAsteroidSky.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/planet/RenderAsteroidSky.java
@@ -233,6 +233,7 @@ public class RenderAsteroidSky extends IRenderHandler {
 		float parentAtmColor[] = new float[]{1f,1f,1f};
 		float parentRingColor[] = new float[] {1f,1f,1f};
 		float ringColor[] = new float[] {1f,1f,1f};
+		float parentGravitationalMultiplier = 0;
 		float sunSize = 1.0f;
 		float starSeperation = 0f;
 		boolean isWarp = false;
@@ -283,6 +284,7 @@ public class RenderAsteroidSky extends IRenderHandler {
 				parentPlanetIcon = getTextureForPlanet(parentProperties);
 				parentHasRings = parentProperties.hasRings;
 				parentRingColor = parentProperties.ringColor;
+				parentGravitationalMultiplier = parentProperties.gravitationalMultiplier;
 			}
 
 			sunColor = planetaryProvider.getSunColor(mc.player.getPosition());
@@ -635,7 +637,7 @@ public class RenderAsteroidSky extends IRenderHandler {
 				GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
 			}
 
-			renderPlanet2(buffer, parentPlanetIcon, 0,0,-100, AstronomicalBodyHelper.getBodySizeMultiplier(planetOrbitalDistance), multiplier, rotation, hasAtmosphere, parentAtmColor, parentRingColor, isGasGiant, false);
+			renderPlanet2(buffer, parentPlanetIcon, 0,0,-100, 20 * AstronomicalBodyHelper.getBodySizeMultiplier(planetOrbitalDistance), multiplier, rotation, hasAtmosphere, parentAtmColor, parentRingColor, isGasGiant, false, parentGravitationalMultiplier);
 			GL11.glPopMatrix();
 		}
 
@@ -671,7 +673,7 @@ public class RenderAsteroidSky extends IRenderHandler {
 			//double rotation = Math.atan2(z,hyp );// - MathHelper.sin((float)moons.orbitTheta);//-Math.PI/2f + Math.atan2(x, y) - (moons.orbitTheta - Math.PI)*MathHelper.sin(phiAngle)*hyp;
 
 
-			renderPlanet(buffer, moons.getPlanetIcon(), (1/(float)moons.getParentOrbitalDistance())*moons.gravitationalMultiplier, multiplier, rotation, moons.hasAtmosphere(), moons.skyColor, moons.ringColor, isGasGiant, moons.hasRings());
+			renderPlanet(buffer, moons.getPlanetIcon(), moons.getParentOrbitalDistance(), multiplier, rotation, moons.hasAtmosphere(), moons.skyColor, moons.ringColor, isGasGiant, moons.hasRings(), moons.gravitationalMultiplier);
 			GL11.glPopMatrix();
 		}
 
@@ -717,12 +719,12 @@ public class RenderAsteroidSky extends IRenderHandler {
 		return EnumFacing.EAST;
 	}
 
-	protected void renderPlanet(BufferBuilder buffer, ResourceLocation icon, float planetOrbitalDistance, float alphaMultiplier, double shadowAngle, boolean hasAtmosphere, float[] skyColor, float[] ringColor, boolean gasGiant, boolean hasRing) {
-		renderPlanet2(buffer, icon, 0, 0, -100, 10f*AstronomicalBodyHelper.getBodySizeMultiplier(planetOrbitalDistance), alphaMultiplier, shadowAngle, hasAtmosphere, skyColor, ringColor, gasGiant, hasRing);
+	protected void renderPlanet(BufferBuilder buffer, ResourceLocation icon, float planetOrbitalDistance, float alphaMultiplier, double shadowAngle, boolean hasAtmosphere, float[] skyColor, float[] ringColor, boolean gasGiant, boolean hasRing, float gravitationalMultiplier) {
+		renderPlanet2(buffer, icon, 0, 0, -100, 20f*AstronomicalBodyHelper.getBodySizeMultiplier(planetOrbitalDistance), alphaMultiplier, shadowAngle, hasAtmosphere, skyColor, ringColor, gasGiant, hasRing, gravitationalMultiplier);
 	}
 
-	protected void renderPlanet2(BufferBuilder buffer, ResourceLocation icon, int locationX, int locationY, double zLevel, float size, float alphaMultiplier, double shadowAngle, boolean hasAtmosphere, float[] skyColor, float[] ringColor, boolean gasGiant, boolean hasRing) {
-		renderPlanetPubHelper(buffer, icon, locationX, locationY, zLevel, size, alphaMultiplier, shadowAngle, hasAtmosphere, skyColor, ringColor, gasGiant, hasRing);
+	protected void renderPlanet2(BufferBuilder buffer, ResourceLocation icon, int locationX, int locationY, double zLevel, float size, float alphaMultiplier, double shadowAngle, boolean hasAtmosphere, float[] skyColor, float[] ringColor, boolean gasGiant, boolean hasRing, float gravitationalMultiplier) {
+		renderPlanetPubHelper(buffer, icon, locationX, locationY, zLevel, 2f*size*gravitationalMultiplier, alphaMultiplier, shadowAngle, hasAtmosphere, skyColor, ringColor, gasGiant, hasRing);
 	}
 
 	protected void rotateAroundAxis() {
@@ -858,7 +860,7 @@ public class RenderAsteroidSky extends IRenderHandler {
 		//Set sun color and distance
 		GlStateManager.color((float)sunColor.x, (float)sunColor.y , (float)sunColor.z ,Math.min((multiplier)*2f,1f));
 		buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);	
-		float f10 = sunSize*30f*AstronomicalBodyHelper.getBodySizeMultiplier(solarOrbitalDistance);
+		float f10 = sunSize*15f*AstronomicalBodyHelper.getBodySizeMultiplier(solarOrbitalDistance);
 		//multiplier = 2;
 		buffer.pos((double)(-f10), 100.0D, (double)(-f10)).tex(0.0D, 0.0D).endVertex();
 		buffer.pos((double)f10, 100.0D, (double)(-f10)).tex(1.0D, 0.0D).endVertex();

--- a/src/main/java/zmaster587/advancedRocketry/client/render/planet/RenderAsteroidSky.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/planet/RenderAsteroidSky.java
@@ -637,7 +637,7 @@ public class RenderAsteroidSky extends IRenderHandler {
 				GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
 			}
 
-			renderPlanet2(buffer, parentPlanetIcon, 0,0,-100, 20 * AstronomicalBodyHelper.getBodySizeMultiplier(planetOrbitalDistance), multiplier, rotation, hasAtmosphere, parentAtmColor, parentRingColor, isGasGiant, false, parentGravitationalMultiplier);
+			renderPlanet2(buffer, parentPlanetIcon, 0,0,-100, 20 * AstronomicalBodyHelper.getBodySizeMultiplier(planetOrbitalDistance), multiplier, rotation, hasAtmosphere, parentAtmColor, parentRingColor, isGasGiant, false, (float)Math.pow(parentGravitationalMultiplier, 0.4));
 			GL11.glPopMatrix();
 		}
 
@@ -673,7 +673,7 @@ public class RenderAsteroidSky extends IRenderHandler {
 			//double rotation = Math.atan2(z,hyp );// - MathHelper.sin((float)moons.orbitTheta);//-Math.PI/2f + Math.atan2(x, y) - (moons.orbitTheta - Math.PI)*MathHelper.sin(phiAngle)*hyp;
 
 
-			renderPlanet(buffer, moons.getPlanetIcon(), moons.getParentOrbitalDistance(), multiplier, rotation, moons.hasAtmosphere(), moons.skyColor, moons.ringColor, isGasGiant, moons.hasRings(), moons.gravitationalMultiplier);
+			renderPlanet(buffer, moons.getPlanetIcon(), moons.getParentOrbitalDistance(), multiplier, rotation, moons.hasAtmosphere(), moons.skyColor, moons.ringColor, isGasGiant, moons.hasRings(), (float)Math.pow(moons.gravitationalMultiplier, 0.4));
 			GL11.glPopMatrix();
 		}
 

--- a/src/main/java/zmaster587/advancedRocketry/client/render/planet/RenderPlanetarySky.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/planet/RenderPlanetarySky.java
@@ -561,7 +561,7 @@ public class RenderPlanetarySky extends IRenderHandler {
 			}
 
 			assert(parentProperties != null);
-			renderPlanet2(buffer, parentProperties, AstronomicalBodyHelper.getBodySizeMultiplier(planetOrbitalDistance), multiplier, rotation, false);
+			renderPlanet(buffer, parentProperties, planetOrbitalDistance, multiplier, rotation, false, false, (float)Math.pow(parentProperties.getGravitationalMultiplier(), 0.4));
 			GL11.glPopMatrix();
 		}
 
@@ -581,7 +581,7 @@ public class RenderPlanetarySky extends IRenderHandler {
 			double y = MathHelper.sin((float)moons.orbitTheta);
 			double rotation = -Math.PI/2f + Math.atan2(x, y) - (moons.orbitTheta - Math.PI)*MathHelper.sin(phiAngle);
 
-			renderPlanet(buffer, moons, moons.getParentOrbitalDistance()*moons.gravitationalMultiplier, multiplier, rotation, moons.hasAtmosphere(), moons.hasRings);
+			renderPlanet(buffer, moons, moons.getParentOrbitalDistance(), multiplier, rotation, moons.hasAtmosphere(), moons.hasRings, (float)Math.pow(moons.gravitationalMultiplier, 0.4));
 			GL11.glPopMatrix();
 		}
 
@@ -652,8 +652,8 @@ public class RenderPlanetarySky extends IRenderHandler {
 		return EnumFacing.EAST;
 	}
 
-	protected void renderPlanet(BufferBuilder buffer, DimensionProperties properties, float planetOrbitalDistance, float alphaMultiplier, double shadowAngle, boolean hasAtmosphere, boolean hasRing) {
-		renderPlanet2(buffer, properties, 10f*AstronomicalBodyHelper.getBodySizeMultiplier(planetOrbitalDistance), alphaMultiplier, shadowAngle, hasRing);
+	protected void renderPlanet(BufferBuilder buffer, DimensionProperties properties, float planetOrbitalDistance, float alphaMultiplier, double shadowAngle, boolean hasAtmosphere, boolean hasRing, float gravitationalMultiplier) {
+		renderPlanet2(buffer, properties, 20f*AstronomicalBodyHelper.getBodySizeMultiplier(planetOrbitalDistance) * gravitationalMultiplier, alphaMultiplier, shadowAngle, hasRing);
 	}
 
 	protected void renderPlanet2(BufferBuilder buffer, DimensionProperties properties, float size, float alphaMultiplier, double shadowAngle, boolean hasRing) {
@@ -838,9 +838,8 @@ public class RenderPlanetarySky extends IRenderHandler {
 
 			//Set sun color and distance
 			GlStateManager.color((float)1, (float).5 , (float).4 ,1f);
-			buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);	
-			float f10 = sunSize*5f*AstronomicalBodyHelper.getBodySizeMultiplier(solarOrbitalDistance);
-			//multiplier = 2;
+			buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);
+			float f10 = sunSize*2.5f*AstronomicalBodyHelper.getBodySizeMultiplier(solarOrbitalDistance);
 			buffer.pos((double)(-f10), 0.0D, (double)(-f10)).tex(0.0D, 0.0D).endVertex();
 			buffer.pos((double)f10, 0.0D, (double)(-f10)).tex(1.0D, 0.0D).endVertex();
 			buffer.pos((double)f10, 0.0D, (double)f10).tex(1.0D, 1.0D).endVertex();
@@ -861,8 +860,8 @@ public class RenderPlanetarySky extends IRenderHandler {
 				GL11.glRotatef((System.currentTimeMillis() % (int)(speedMult*36000))/(100f*speedMult), 0, 1, 0);
 
 				GlStateManager.color((float)1, (float).5 , (float).4 ,1f);
-				buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);	
-				f10 = sunSize*40f*AstronomicalBodyHelper.getBodySizeMultiplier(solarOrbitalDistance);
+				buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);
+				f10 = sunSize*20f*AstronomicalBodyHelper.getBodySizeMultiplier(solarOrbitalDistance);
 				buffer.pos((double)(-f10), 0.0D, (double)(-f10)).tex(0.0D, 0.0D).endVertex();
 				buffer.pos((double)f10, 0.0D, (double)(-f10)).tex(1.0D, 0.0D).endVertex();
 				buffer.pos((double)f10, 0.0D, (double)f10).tex(1.0D, 1.0D).endVertex();
@@ -878,7 +877,7 @@ public class RenderPlanetarySky extends IRenderHandler {
 
 				GlStateManager.color((float)0.8, (float).7 , (float).4 ,1f);
 				buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);	
-				f10 = sunSize*30f*AstronomicalBodyHelper.getBodySizeMultiplier(solarOrbitalDistance);
+				f10 = sunSize*15f*AstronomicalBodyHelper.getBodySizeMultiplier(solarOrbitalDistance);
 				//multiplier = 2;
 				buffer.pos((double)(-f10), 0.0D, (double)(-f10)).tex(0.0D, 0.0D).endVertex();
 				buffer.pos((double)f10, 0.0D, (double)(-f10)).tex(1.0D, 0.0D).endVertex();
@@ -895,7 +894,7 @@ public class RenderPlanetarySky extends IRenderHandler {
 
 				GlStateManager.color((float)0.2, (float).4 , (float)1 ,1f);
 				buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);	
-				f10 = sunSize*15f*AstronomicalBodyHelper.getBodySizeMultiplier(solarOrbitalDistance);
+				f10 = sunSize*7.5f*AstronomicalBodyHelper.getBodySizeMultiplier(solarOrbitalDistance);
 				//multiplier = 2;
 				buffer.pos((double)(-f10), 0.0D, (double)(-f10)).tex(0.0D, 0.0D).endVertex();
 				buffer.pos((double)f10, 0.0D, (double)(-f10)).tex(1.0D, 0.0D).endVertex();
@@ -915,7 +914,7 @@ public class RenderPlanetarySky extends IRenderHandler {
 			//Set sun color and distance
 			GlStateManager.color((float)sunColor.x, (float)sunColor.y , (float)sunColor.z ,Math.min((multiplier)*2f,1f));
 			buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);	
-			float f10 = sunSize*30f*AstronomicalBodyHelper.getBodySizeMultiplier(solarOrbitalDistance);
+			float f10 = sunSize*15f*AstronomicalBodyHelper.getBodySizeMultiplier(solarOrbitalDistance);
 			//multiplier = 2;
 			buffer.pos((double)(-f10), 100.0D, (double)(-f10)).tex(0.0D, 0.0D).endVertex();
 			buffer.pos((double)f10, 100.0D, (double)(-f10)).tex(1.0D, 0.0D).endVertex();

--- a/src/main/java/zmaster587/advancedRocketry/client/render/planet/RenderPlanetarySky.java
+++ b/src/main/java/zmaster587/advancedRocketry/client/render/planet/RenderPlanetarySky.java
@@ -568,7 +568,6 @@ public class RenderPlanetarySky extends IRenderHandler {
 		for(DimensionProperties moons : children) {
 			GL11.glPushMatrix();
 
-			moons.orbitalPhi = 10;
 			double rot = ((partialTicks*moons.orbitTheta + ((1-partialTicks)*moons.prevOrbitalTheta)) * 180F/Math.PI);
 
 			GL11.glRotatef((float)moons.orbitalPhi, 0f, 0f, 1f);

--- a/src/main/java/zmaster587/advancedRocketry/util/XMLPlanetLoader.java
+++ b/src/main/java/zmaster587/advancedRocketry/util/XMLPlanetLoader.java
@@ -331,7 +331,7 @@ public class XMLPlanetLoader {
 			else if(planetPropertyNode.getNodeName().equalsIgnoreCase(ELEMENT_BASEORBITTHETA)) {
 
 				try {
-					properties.baseOrbitTheta = (Integer.parseInt(planetPropertyNode.getTextContent()) % 360) * Math.PI/180f;
+					properties.baseOrbitTheta = ((Integer.parseInt(planetPropertyNode.getTextContent()) + 180) % 360) * Math.PI/180f;
 				} catch (NumberFormatException e) {
 					AdvancedRocketry.logger.warn("Invalid orbitalTheta specified"); //TODO: more detailed error msg
 				}
@@ -863,7 +863,7 @@ public class XMLPlanetLoader {
 		nodePlanet.appendChild(createTextNode(doc, ELEMENT_SKYCOLOR, properties.skyColor[0] + "," + properties.skyColor[1] + "," + properties.skyColor[2]));
 		nodePlanet.appendChild(createTextNode(doc, ELEMENT_GRAVITY, (int)(properties.getGravitationalMultiplier()*100f)));
 		nodePlanet.appendChild(createTextNode(doc, ELEMENT_DISTANCE, properties.getOrbitalDist()));
-		nodePlanet.appendChild(createTextNode(doc, ELEMENT_BASEORBITTHETA, (int)(properties.baseOrbitTheta * 180f/Math.PI)));
+		nodePlanet.appendChild(createTextNode(doc, ELEMENT_BASEORBITTHETA, (int)((properties.baseOrbitTheta * 180f/Math.PI) - 180)));
 		nodePlanet.appendChild(createTextNode(doc, ELEMENT_PHI, (int)(properties.orbitalPhi)));
 		nodePlanet.appendChild(createTextNode(doc, AVG_TEMPERATURE, (int)(properties.averageTemperature)));
 		nodePlanet.appendChild(createTextNode(doc, ELEMENT_PERIOD, properties.rotationalPeriod));


### PR DESCRIPTION
Fixes a bunch of bugs with planetary size calculations and adds extra scaling mechanics to complete the parity where before only one body of a planet-moon system would scale. Star sizes are also halved to bring them into parity with the moon size.