### PR TITLE
Correct gradle build text replacement and version #s

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'java'
 apply plugin: 'net.minecraftforge.gradle.forge'
 
 group= "zmaster587.advancedRocketry" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = "AdvancedRocketry"
+archivesBaseName = project.archivebase
 sourceCompatibility = 8
 targetCompatibility = 8
 
@@ -43,9 +43,9 @@ minecraft {
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
     replaceIn "src/main/java/zmaster587/advancedRocketry/AdvancedRocketry.java"
-    replace "@MAJOR@", version_major
-    replace "@MINOR@", version_minor
-    replace "@REVIS@", version_revis
+    replace "@MAJOR@", project.version_major
+    replace "@MINOR@", project.version_minor
+    replace "@REVIS@", project.version_revis
     replace "@BUILD@", project.getBuildNumber()
     
     replace "%LIBVULPESVERSION%", project.libVulpesVersion

--- a/src/main/java/zmaster587/advancedRocketry/AdvancedRocketry.java
+++ b/src/main/java/zmaster587/advancedRocketry/AdvancedRocketry.java
@@ -149,7 +149,7 @@ public class AdvancedRocketry {
 	@SidedProxy(clientSide="zmaster587.advancedRocketry.client.ClientProxy", serverSide="zmaster587.advancedRocketry.common.CommonProxy")
 	public static CommonProxy proxy;
 
-	public final static String version = "@MAJOR@.@MINOR@.@REVIS@@BUILD@";
+	public final static String version = "@MAJOR@.@MINOR@.@REVIS@.@BUILD@";
 
 	@Instance(value = Constants.modId)
 	public static AdvancedRocketry instance;


### PR DESCRIPTION
I can't compile, so I can't test, but these changes should fix broken version numbers in the compiled mod metadata.

Line 27 of build.gradle is mainly there for consistency and string deduplication, but I can revert that if you don't want it.