### PR TITLE
Fix biome spawning on cold planets and setting the LEO explicitly in PlanetIcons, moved line in StellarBody

### DIFF
--- a/src/main/java/zmaster587/advancedRocketry/api/dimension/solar/StellarBody.java
+++ b/src/main/java/zmaster587/advancedRocketry/api/dimension/solar/StellarBody.java
@@ -190,9 +190,8 @@ public class StellarBody {
 		else {
 			color[1] = temperature - 60;
 			color[1] = 288f * (float)Math.pow(color[1], -0.07551);
-
+			color[1] = MathHelper.clamp(color[1]/255f, 0f, 1f);
 		}
-		color[1] = MathHelper.clamp(color[1]/255f, 0f, 1f);
 
 
 		//Calculate Blue

--- a/src/main/java/zmaster587/advancedRocketry/dimension/DimensionProperties.java
+++ b/src/main/java/zmaster587/advancedRocketry/dimension/DimensionProperties.java
@@ -189,7 +189,7 @@ public class DimensionProperties implements Cloneable, IDimensionProperties {
 		PlanetIcons(ResourceLocation resource, ResourceLocation leo) {
 			this.resource = resource;
 
-			this.resourceLEO = atmosphereLEO;
+			this.resourceLEO = leo;
 		}
 
 		public ResourceLocation getResource() {
@@ -1129,14 +1129,14 @@ public class DimensionProperties implements Cloneable, IDimensionProperties {
 		else if(Temps.getTempFromValue(averageTemperature).hotterThan(Temps.FRIGID)) {
 
 			for (Biome biome : Biome.REGISTRY) {
-				if (biome != null && !BiomeDictionary.getTypes(biome).contains(BiomeDictionary.Type.COLD) && !isBiomeblackListed(biome)) {
+				if (biome != null && BiomeDictionary.getTypes(biome).contains(BiomeDictionary.Type.COLD) && !isBiomeblackListed(biome)) {
 					viableBiomes.add(biome);
 				}
 			}
 		}
 		else {
 			for (Biome biome : Biome.REGISTRY) {
-				if (biome != null && !BiomeDictionary.getTypes(biome).contains(BiomeDictionary.Type.COLD) && !isBiomeblackListed(biome)) {
+				if (biome != null && BiomeDictionary.getTypes(biome).contains(BiomeDictionary.Type.COLD) && !isBiomeblackListed(biome)) {
 					viableBiomes.add(biome);
 				}
 			}


### PR DESCRIPTION
-Frigid and snowball planets spawn cold biomes now. 
-Setting the LEO in PlanetIcons explicitly will now work properly instead of just setting the LEO to the atmosphere LEO.
-Moved a line of code in StellarBody which seemed to be in the wrong place.