### PR TITLE
Small fix, allows AR Skyboxes to be forcefully rendered on ALL worlds unless skyOverride is false

### DIFF
--- a/src/main/java/zmaster587/advancedRocketry/event/PlanetEventHandler.java
+++ b/src/main/java/zmaster587/advancedRocketry/event/PlanetEventHandler.java
@@ -401,7 +401,7 @@ public class PlanetEventHandler {
 	public void worldLoadEvent(WorldEvent.Load event) {
 		if(!event.getWorld().isRemote)
 			AtmosphereHandler.registerWorld(event.getWorld().provider.getDimension());
-		else if(ARConfiguration.getCurrentConfig().skyOverride && event.getWorld().provider.getDimension() == 0)
+		else if(ARConfiguration.getCurrentConfig().skyOverride)
 			event.getWorld().provider.setSkyRenderer(new RenderPlanetarySky());
 	}
 


### PR DESCRIPTION
This is the cause behind dimMapped Worlds not receiving there skyboxes when relogging/teleporting to the world that isnt generated by AR

In my testing this didn't seem to interfere with anything else, I have tried this with Lost Cities & Atum 2, you can see the video of the fix in action here: https://discord.com/channels/399708323126968321/822730674321489920/1134942642770284614

Setting skyOverride to false will allow for the original sky to be rendered if someone doesn't want the AR Sky (Why would they not? :p)